### PR TITLE
Guard Smart Mask installs against NumPy 2

### DIFF
--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -142,7 +142,7 @@ function run(command, args, options = {}) {
   });
 }
 
-function requirementsArgs(requirements, repair = false) {
+function requirementsArgs(requirements, repair = false, options = {}) {
   // Never use pip's blanket --upgrade here. ComfyUI custom nodes share one
   // Python environment, so an unrelated node installer can otherwise replace
   // Video Helper Suite / SeedVR2 dependencies. Normal installs are additive;
@@ -150,6 +150,10 @@ function requirementsArgs(requirements, repair = false) {
   const args = ['-m', 'pip', 'install', '--upgrade-strategy', 'only-if-needed'];
   if (repair) args.push('--force-reinstall', '--no-deps');
   args.push('-r', requirements);
+  // ComfyUI-SAM3 depends on comfy-env, whose unconstrained NumPy dependency
+  // can otherwise pull in NumPy 2. That breaks the OpenCV wheels used by
+  // Video Helper Suite, SeedVR2, and several long-lived ComfyUI node packs.
+  if (!repair && options.keepNumpy1) args.push('numpy<2');
   return args;
 }
 
@@ -195,7 +199,9 @@ async function installNodePack(pack, status, report, options = {}) {
     report('requirements', repair
       ? `Repairing ${pack.label} requirements without changing unrelated packages`
       : `Installing ${pack.label} requirements without upgrading unrelated packages`);
-    await runCommand(status.pythonPath, requirementsArgs(requirements, repair), { cwd: nodePath });
+    await runCommand(status.pythonPath, requirementsArgs(requirements, repair, {
+      keepNumpy1: pack === NODE_PACKS.sam3,
+    }), { cwd: nodePath });
   }
   const installScript = path.join(nodePath, 'install.py');
   if (existsSync(installScript)) {

--- a/test/dependency-manager.test.js
+++ b/test/dependency-manager.test.js
@@ -16,6 +16,7 @@ const {
   NODE_PACKS,
   availableComponents,
   cleanRelative,
+  requirementsArgs,
   sameRepo,
 } = require('../lib/dependency-installer');
 const { comfyPort, restartStatus } = require('../lib/comfy-restart');
@@ -87,4 +88,12 @@ test('node installs preserve unrelated ComfyUI packages and make a repair explic
   assert.match(installer, /snapshotPythonEnvironment/);
   assert.match(sam3, /--upgrade-strategy', 'only-if-needed'/);
   assert.doesNotMatch(sam3, /'--upgrade', '-r'/);
+});
+
+test('Smart Mask dependency installs retain the NumPy 1 compatibility line', () => {
+  assert.deepEqual(
+    requirementsArgs('requirements.txt', false, { keepNumpy1: true }).slice(-2),
+    ['requirements.txt', 'numpy<2']
+  );
+  assert.equal(requirementsArgs('requirements.txt', true, { keepNumpy1: true }).includes('numpy<2'), false);
 });


### PR DESCRIPTION
## What changed

- Constrain Smart Mask dependency installation to the NumPy 1.x compatibility line.
- Add a regression test for the installer arguments.

## Why

ComfyUI-SAM3 depends on `comfy-env`, whose unconstrained NumPy dependency could upgrade the shared ComfyUI environment to NumPy 2. That made the existing OpenCV wheel fail to import, disabling Video Helper Suite and SeedVR2 nodes.

## Impact

New Smart Mask installs keep OpenCV-based custom nodes compatible instead of leaving them in a `needs attention` state.

## Validation

- `node --check server.js`
- `node --test`