### PR TITLE
Improve queue history and reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MixBox Studio
+# Mix Studio
 
 Minimalist, mobile-first web app for driving a local **ComfyUI** install — image and video generation in the Modatory design language. Generations run on the Windows desktop; you drive it from your phone (same Wi-Fi or Tailscale). Zero dependencies: one Node.js server, vanilla JS frontend, no build step.
 
@@ -17,8 +17,8 @@ The current bootstrap supports an existing ComfyUI installation and can install 
    git clone https://github.com/BlackMixture/KreaStudio.git
    ```
 
-3. Open the cloned folder and double-click **install.bat**. A MixBox Studio-styled setup window walks through prerequisites, ComfyUI connection, optional model families, review, and installation.
-4. Enter the URL and optional folders for an existing ComfyUI installation. Existing models stay where they are; MixBox Studio does not copy or redownload them.
+3. Open the cloned folder and double-click **install.bat**. A Mix Studio-styled setup window walks through prerequisites, ComfyUI connection, optional model families, review, and installation.
+4. Enter the URL and optional folders for an existing ComfyUI installation. Existing models stay where they are; Mix Studio does not copy or redownload them.
 5. Choose which optional Edit and Video model families should appear in the interface.
 6. Start ComfyUI, then double-click **start.bat**.
 
@@ -35,28 +35,28 @@ If the phone can't connect, allow Node through Windows Defender Firewall (privat
 
 ### Existing ComfyUI and shared models
 
-The installer supports an existing ComfyUI URL, application folder, and models folder. MixBox Studio uses those paths for local LoRA metadata and SeedVR2 discovery, while ComfyUI remains responsible for loading the models used by generation graphs. If your models folder is outside the ComfyUI folder, make sure that ComfyUI already includes it through its `extra_model_paths.yaml` configuration.
+The installer supports an existing ComfyUI URL, application folder, and models folder. Mix Studio uses those paths for local LoRA metadata and SeedVR2 discovery, while ComfyUI remains responsible for loading the models used by generation graphs. If your models folder is outside the ComfyUI folder, make sure that ComfyUI already includes it through its `extra_model_paths.yaml` configuration.
 
 You can rerun **install.bat** later to change these paths or optional feature families. Existing settings are used as the defaults and backed up before the merged configuration is saved.
 
-To remove MixBox Studio, double-click **uninstall.bat**. The uninstaller removes the portable app checkout but keeps `data/` by default so profiles and generated media can be reused after reinstalling. Use the explicit `-RemoveData` option only when you also want to erase that local gallery data; it requires typing `DELETE`. ComfyUI, shared model folders, and the system Node.js installation are never removed.
+To remove Mix Studio, double-click **uninstall.bat**. The uninstaller removes the portable app checkout but keeps `data/` by default so profiles and generated media can be reused after reinstalling. Use the explicit `-RemoveData` option only when you also want to erase that local gallery data; it requires typing `DELETE`. ComfyUI, shared model folders, and the system Node.js installation are never removed.
 
 ### Installing missing dependencies
 
-In **Advanced Settings → General**, the **Desktop Dependencies** card scans every enabled MixBox model and node family. The owner profile can install only the red groups; node packs are cloned into the configured `custom_nodes` directory and their requirements are added with that ComfyUI instance's Python environment **without a blanket pip upgrade**. Before any node requirements are changed, MixBox Studio saves a `pip freeze` snapshot under `data/dependency-backups/`. Model files download into the configured shared models folder with live byte progress, and partial downloads are kept as `.mixbox.part` files until complete.
+In **Advanced Settings → General**, the **Desktop Dependencies** card scans every enabled Mix Studio model and node family. The owner profile can install only the red groups; node packs are cloned into the configured `custom_nodes` directory and their requirements are added with that ComfyUI instance's Python environment **without a blanket pip upgrade**. Before any node requirements are changed, Mix Studio saves a `pip freeze` snapshot under `data/dependency-backups/`. Model files download into the configured shared models folder with live byte progress, and partial downloads are kept as `.mixbox.part` files until complete.
 
 Use **Repair missing tools** after an interrupted install or a custom-node dependency conflict. It reinstalls only the affected packs' declared Python packages, then asks for a ComfyUI restart; it does not reset profiles, gallery data, model files, or unrelated custom nodes.
 
-Some upstream Hugging Face files require accepting a license before their download URL will work. Accept the license on the model page first; if the provider requires authentication, launch MixBox Studio with an `HF_TOKEN` environment variable. The card also exposes **Restart ComfyUI** for a configured Windows ComfyUI folder, but it will refuse while either queue is active.
+Some upstream Hugging Face files require accepting a license before their download URL will work. Accept the license on the model page first; if the provider requires authentication, launch Mix Studio with an `HF_TOKEN` environment variable. The card also exposes **Restart ComfyUI** for a configured Windows ComfyUI folder, but it will refuse while either queue is active.
 
 ### Updating
 
-Open MixBox Studio's side menu and choose **Update app**. Updates require:
+Open Mix Studio's side menu and choose **Update app**. Updates require:
 
 - a Git clone with its `.git` directory;
 - a named branch and configured `origin` remote;
 - no uncommitted tracked code changes; and
-- idle MixBox Studio and ComfyUI queues.
+- idle Mix Studio and ComfyUI queues.
 
 Machine-specific `install.json` and all `data/` content are ignored by Git, so normal updates do not replace profiles, settings, metadata, or generations. Server-side updates restart the Node process automatically; frontend-only updates do not need a restart.
 

--- a/docs/portable-install.md
+++ b/docs/portable-install.md
@@ -1,6 +1,6 @@
 # Portable installation and updates
 
-MixBox Studio uses a portable Git checkout on Windows. The application, installer, and updater remain readable and editable; profiles and generated media stay in the ignored `data/` directory.
+Mix Studio uses a portable Git checkout on Windows. The application, installer, and updater remain readable and editable; profiles and generated media stay in the ignored `data/` directory.
 
 This first bootstrap configures an existing ComfyUI installation. Automatic ComfyUI, custom-node, and model-pack downloads remain a separate installer phase because every artifact needs a pinned source, checksum, destination, and license acknowledgement. The optional families are already represented in `installer/feature-manifest.json` so that phase can use the same choices as the interface.
 
@@ -8,7 +8,7 @@ This first bootstrap configures an existing ComfyUI installation. Automatic Comf
 
 1. Install Git for Windows.
 2. Clone `https://github.com/BlackMixture/KreaStudio.git`.
-3. Double-click `install.bat`. The native Windows wizard uses the same black surfaces, compact cards, spectrum accents, and restrained motion as the MixBox Studio web interface.
+3. Double-click `install.bat`. The native Windows wizard uses the same black surfaces, compact cards, spectrum accents, and restrained motion as the Mix Studio web interface.
 4. Let setup install Node.js LTS with `winget` if Node 22+ is not already available, then rerun `install.bat` after PATH refreshes.
 5. Enter the running ComfyUI URL. If ComfyUI and its models already exist, enter those folders to reuse them in place.
 6. Enable only the Edit and Video model families installed on that machine.
@@ -27,15 +27,15 @@ All are machine-specific and ignored by Git. The installer does not delete or re
 
 ## Uninstalling
 
-Double-click `uninstall.bat` in the checkout. It removes the portable MixBox Studio application files after the confirmation and keeps the local `data/` folder by default. This makes a later reinstall possible without losing profiles, settings, uploads, or generations. The uninstaller never removes ComfyUI, shared model folders, or Node.js.
+Double-click `uninstall.bat` in the checkout. It removes the portable Mix Studio application files after the confirmation and keeps the local `data/` folder by default. This makes a later reinstall possible without losing profiles, settings, uploads, or generations. The uninstaller never removes ComfyUI, shared model folders, or Node.js.
 
 For a full local removal, run `uninstall.bat -RemoveData` and type `DELETE` when prompted. This deletes the checkout and its local `data/` folder; external data and model paths are not touched.
 
 ## Reusing models
 
-MixBox Studio sends model filenames to the connected ComfyUI API. The selected ComfyUI instance must therefore already see the model folder. For a separate shared-model directory, add it to ComfyUI's `extra_model_paths.yaml`; the installer does not modify an existing ComfyUI configuration without permission.
+Mix Studio sends model filenames to the connected ComfyUI API. The selected ComfyUI instance must therefore already see the model folder. For a separate shared-model directory, add it to ComfyUI's `extra_model_paths.yaml`; the installer does not modify an existing ComfyUI configuration without permission.
 
-The optional local models path additionally lets MixBox Studio discover LoRA metadata and SeedVR2 files directly. No model is copied merely to satisfy the portable app layout.
+The optional local models path additionally lets Mix Studio discover LoRA metadata and SeedVR2 files directly. No model is copied merely to satisfy the portable app layout.
 
 ## Updates
 

--- a/install.bat
+++ b/install.bat
@@ -1,11 +1,11 @@
 @echo off
 setlocal
-title MixBox Studio Installer
+title Mix Studio Installer
 cd /d "%~dp0"
 if not exist "%~dp0installer\install-ui.ps1" (
-  echo MixBox Studio Setup could not find installer\install-ui.ps1.
+  echo Mix Studio Setup could not find installer\install-ui.ps1.
   pause
   exit /b 1
 )
-start "MixBox Studio Setup" "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -STA -WindowStyle Hidden -File "%~dp0installer\install-ui.ps1"
+start "Mix Studio Setup" "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -STA -WindowStyle Hidden -File "%~dp0installer\install-ui.ps1"
 exit /b 0

--- a/installer/feature-manifest.json
+++ b/installer/feature-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "product": "MixBox Studio",
+  "product": "Mix Studio",
   "target": "windows-nvidia",
   "notes": "The bootstrapper uses this selection to install only the required model families and writes the same keys to data/settings.json. Model source URLs and license acknowledgements are resolved separately by the installer.",
   "features": [

--- a/installer/install-ui.ps1
+++ b/installer/install-ui.ps1
@@ -7,8 +7,8 @@ Add-Type -AssemblyName System.Windows.Forms
 
 trap {
   [System.Windows.MessageBox]::Show(
-    "MixBox Studio Setup could not open.`n`n$($_.Exception.Message)",
-    'MixBox Studio Setup',
+    "Mix Studio Setup could not open.`n`n$($_.Exception.Message)",
+    'Mix Studio Setup',
     [System.Windows.MessageBoxButton]::OK,
     [System.Windows.MessageBoxImage]::Error
   ) | Out-Null
@@ -24,7 +24,7 @@ $EngineFile = Join-Path $PSScriptRoot 'install.ps1'
 [xml]$Xaml = @'
 <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="MixBox Studio Setup" Width="980" Height="720" MinWidth="860" MinHeight="640"
+        Title="Mix Studio Setup" Width="980" Height="720" MinWidth="860" MinHeight="640"
         WindowStartupLocation="CenterScreen" Background="#000000" Foreground="#F6F8FF"
         FontFamily="Segoe UI" ResizeMode="CanResizeWithGrip">
   <Window.Resources>
@@ -163,15 +163,22 @@ $EngineFile = Join-Path $PSScriptRoot 'install.ps1'
           <Border Width="48" Height="48" CornerRadius="15" BorderThickness="2" BorderBrush="{StaticResource Spectrum}"
                   Background="#090B10" Padding="8">
             <Viewbox>
-              <Canvas Width="44" Height="46">
-                <Polygon Points="22,2 40,12 22,22 4,12" Fill="#FBBC04"/>
-                <Polygon Points="4,14 21,24 21,44 4,34" Fill="#4285F4"/>
-                <Polygon Points="23,24 40,14 40,34 23,44" Fill="#7C4DFF"/>
+              <Canvas Width="734.42" Height="753.63">
+                <Path Fill="#fdc302" Data="M615.65 208.12c-15.14-3.45-30.62-1.14-44.15 7.05L366.77 339.12l-82.59-50.59-121.3-73.24c-13.51-8.16-29.27-10.69-44.22-7.24l-.38-36.63c-.19-18.31 7.8-38.19 24.31-47.95L339 7.31c16.59-9.81 38.81-9.68 55.26-.02l190.82 111.96c18.08 10.61 30.68 27.5 30.64 49.47l-.08 39.4Z"/>
+                <Path Fill="#47ad49" Data="m366.77 339.12.09.87-48.9 31.04-59.13 36.83c-12.32 7.67-19 19.03-23.8 32.13-2.52-1.15-4.65-2.62-7.36-4.35l-80.77-51.51c-17.97-11.46-28.62-29-28.66-50.54L118 208.69l.66-.64c14.95-3.45 30.71-.92 44.22 7.24l121.3 73.24 82.59 50.59Z"/>
+                <Path Fill="#432dd0" Data="m332.59 501.15 34.33 21.71-.18 179.91.13.97c-.22-.13-.57 0-.81-.09-35.73-24.32-73.67-45.47-110.31-69.84-13.42-8.92-21.64-25.24-21.67-41.48l-.32-137.55c-.01-4.96.41-9.12 1.4-13.36.91.05 1.9.37 2.9.98l22.1 13.57 72.44 45.17Z"/>
+                <Path Fill="#564aa7" Data="m366.92 522.86-34.33-21.71-72.44-45.17-22.1-13.57c-1-.61-1.99-.93-2.9-.98.1-.43-.28-1.02-.12-1.44 4.81-13.1 11.49-24.46 23.8-32.13l59.13-36.83 48.91-31.04.05 182.87Z"/>
+                <Path Fill="#822292" Data="M499.44 441.41c.94 2.58 1.52 5.3 1.51 8.73l-.21 142.47c-.03 18.67-10.55 34.44-25.85 43.95l-104.6 65.01c-1.35.84-2.57.73-3.55 1.2l.18-179.91 92.76-57.37 31.62-19.69c2.77-1.72 5.25-3.57 8.15-4.39Z"/>
+                <Path Fill="#973975" Data="M499.54 440.09c.11.4-.16.91-.1 1.32-2.9.82-5.39 2.67-8.15 4.39l-31.62 19.69-92.76 57.37-.05-182.87c1.98.17 3.37 1.31 5.38 2.56l104.15 65.36c11.88 7.46 19.61 19.04 23.15 32.17Z"/>
+                <Path Fill="#026cfc" Data="m118 208.7.24 124.9c.04 21.54 10.69 39.08 28.66 50.54l80.77 51.51c2.71 1.73 4.84 3.2 7.36 4.35-.15.42.22 1.01.12 1.44-.98 4.23-1.41 8.4-1.4 13.36l.32 137.55c.04 16.25 8.25 32.56 21.67 41.48 36.65 24.36 74.58 45.52 110.31 69.84l-71.48 42.61c-16.45 9.81-39.02 9.86-55.74-.07L28.62 621.52C12.66 612.05.29 594.24.27 574.83L0 304.32c-.02-17.99 9.59-35.35 24.74-44.31l74.56-44.12c6.08-3.6 12.06-6.74 18.7-7.2Z"/>
+                <Path Fill="#fb2026" Data="M734.42 308.79c-.63-.38-1.3-.07-1.56 1.06V576.2c.21.86.39 1.09.83 1-1.39 17.82-11.84 34.61-27.56 44.06L501.5 744.21c-20.46 12.29-44.38 11.76-65.01-.17l-69.63-40.28-.13-.97c.98-.46 2.21-.36 3.55-1.2l104.6-65.01c15.3-9.51 25.83-25.28 25.85-43.95l.21-142.47c0-3.43-.57-6.15-1.51-8.73-.06-.41.21-.92.1-1.32 1.1-.15 1.99-.65 3.27-1.49l90.13-58.72c13.61-8.87 22.36-24.62 22.4-40.8l.31-130.96c6.52 1.49 12.24 3.64 18.42 7.3l77.83 46.13c16.79 9.95 22.53 29.12 22.52 47.24Z"/>
+                <Path Fill="#fa0f17" Data="m734.42 308.79-.04 263.53c0 2.07-.58 3.41-.69 4.88-.44.1-.62-.13-.83-1V309.85c.25-1.13.92-1.44 1.55-1.06Z"/>
+                <Path Fill="#fc6f01" Data="m615.65 208.12-.31 130.96c-.04 16.18-8.79 31.93-22.4 40.8l-90.13 58.72c-1.28.83-2.17 1.33-3.27 1.49-3.54-13.13-11.27-24.71-23.15-32.17l-104.15-65.36c-2-1.26-3.4-2.39-5.38-2.56l-.09-.87L571.5 215.18c13.53-8.19 29.02-10.5 44.15-7.05Z"/>
               </Canvas>
             </Viewbox>
           </Border>
           <StackPanel Margin="14,0,0,0" VerticalAlignment="Center">
-            <TextBlock Text="MixBox Studio" FontSize="20" FontWeight="Bold"/>
+            <TextBlock Text="Mix Studio" FontSize="20" FontWeight="Bold"/>
             <TextBlock Text="Portable setup" Foreground="{StaticResource Muted}" FontSize="12" Margin="0,3,0,0"/>
           </StackPanel>
         </StackPanel>
@@ -210,7 +217,7 @@ $EngineFile = Join-Path $PSScriptRoot 'install.ps1'
           <Grid x:Name="PageWelcome">
             <StackPanel VerticalAlignment="Center" MaxWidth="610">
               <TextBlock Text="Build your local studio" FontSize="34" FontWeight="Bold"/>
-              <TextBlock Text="A portable MixBox Studio connected to the ComfyUI and models already on your machine." TextWrapping="Wrap" FontSize="16" Foreground="{StaticResource Soft}" Margin="0,12,0,28" LineHeight="24"/>
+              <TextBlock Text="A portable Mix Studio connected to the ComfyUI and models already on your machine." TextWrapping="Wrap" FontSize="16" Foreground="{StaticResource Soft}" Margin="0,12,0,28" LineHeight="24"/>
               <Grid>
                 <Grid.ColumnDefinitions><ColumnDefinition/><ColumnDefinition Width="12"/><ColumnDefinition/></Grid.ColumnDefinitions>
                 <Border Grid.Column="0" Background="#07090D" BorderBrush="#232936" BorderThickness="1" CornerRadius="16" Padding="18">
@@ -230,7 +237,7 @@ $EngineFile = Join-Path $PSScriptRoot 'install.ps1'
             <ScrollViewer VerticalScrollBarVisibility="Auto">
               <StackPanel MaxWidth="650">
                 <TextBlock Text="Connect ComfyUI" FontSize="30" FontWeight="Bold"/>
-                <TextBlock Text="Point MixBox Studio at the ComfyUI installation that performs generation." Foreground="{StaticResource Soft}" FontSize="15" Margin="0,9,0,25"/>
+                <TextBlock Text="Point Mix Studio at the ComfyUI installation that performs generation." Foreground="{StaticResource Soft}" FontSize="15" Margin="0,9,0,25"/>
                 <TextBlock Text="COMFYUI URL" Foreground="{StaticResource Muted}" FontSize="11" FontWeight="Bold"/>
                 <Grid Margin="0,8,0,18"><Grid.ColumnDefinitions><ColumnDefinition/><ColumnDefinition Width="10"/><ColumnDefinition Width="118"/></Grid.ColumnDefinitions><TextBox x:Name="ComfyUrlBox" Text="http://127.0.0.1:8188"/><Button x:Name="TestComfyButton" Grid.Column="2" Style="{StaticResource BaseButton}" Content="Test connection" Padding="12,10"/></Grid>
                 <Border x:Name="ConnectionStatus" Visibility="Collapsed" Background="#0C1116" BorderBrush="#273342" BorderThickness="1" CornerRadius="12" Padding="13" Margin="0,0,0,18"><TextBlock x:Name="ConnectionStatusText" TextWrapping="Wrap"/></Border>
@@ -270,7 +277,7 @@ $EngineFile = Join-Path $PSScriptRoot 'install.ps1'
           <Grid x:Name="PageProgress" Visibility="Collapsed">
             <StackPanel MaxWidth="610" VerticalAlignment="Center" HorizontalAlignment="Center">
               <Border Width="76" Height="76" CornerRadius="24" BorderBrush="{StaticResource Spectrum}" BorderThickness="2" Background="#0B0E15"><TextBlock Text="↻" FontSize="34" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#A9BDF6"/></Border>
-              <TextBlock Text="Setting up MixBox Studio" FontSize="28" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,22,0,8"/>
+              <TextBlock Text="Setting up Mix Studio" FontSize="28" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,22,0,8"/>
               <TextBlock x:Name="ProgressDetail" Text="Preparing your portable configuration…" Foreground="{StaticResource Muted}" HorizontalAlignment="Center"/>
               <ProgressBar x:Name="InstallProgress" Height="5" IsIndeterminate="True" Margin="0,26,0,0" Background="#151923" Foreground="#526FFF"/>
             </StackPanel>
@@ -280,8 +287,8 @@ $EngineFile = Join-Path $PSScriptRoot 'install.ps1'
             <StackPanel MaxWidth="610" VerticalAlignment="Center" HorizontalAlignment="Center">
               <Border Width="76" Height="76" CornerRadius="24" Background="#0B1710" BorderBrush="#315D3C" BorderThickness="1"><TextBlock Text="✓" FontSize="34" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#7DDF95"/></Border>
               <TextBlock Text="Your studio is ready" FontSize="30" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,22,0,8"/>
-              <TextBlock Text="Start ComfyUI, then open MixBox Studio from this portable folder." Foreground="{StaticResource Soft}" TextAlignment="Center" TextWrapping="Wrap" FontSize="15"/>
-              <Button x:Name="LaunchButton" Style="{StaticResource PrimaryButton}" Content="Launch MixBox Studio" Margin="0,28,0,0" MinWidth="240"/>
+              <TextBlock Text="Start ComfyUI, then open Mix Studio from this portable folder." Foreground="{StaticResource Soft}" TextAlignment="Center" TextWrapping="Wrap" FontSize="15"/>
+              <Button x:Name="LaunchButton" Style="{StaticResource PrimaryButton}" Content="Launch Mix Studio" Margin="0,28,0,0" MinWidth="240"/>
               <TextBlock Text="Your first profile is created inside the app." Foreground="{StaticResource Muted}" HorizontalAlignment="Center" FontSize="12" Margin="0,14,0,0"/>
             </StackPanel>
           </Grid>
@@ -492,7 +499,7 @@ function Test-ComfyConnection {
     $Response.Close()
     $Status.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#315D3C')
     $Text.Foreground = [Windows.Media.BrushConverter]::new().ConvertFromString('#9FD8AE')
-    $Text.Text = 'Connected. ComfyUI is ready to answer MixBox Studio.'
+    $Text.Text = 'Connected. ComfyUI is ready to answer Mix Studio.'
   } catch {
     $Status.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#704141')
     $Text.Foreground = [Windows.Media.BrushConverter]::new().ConvertFromString('#F0A8A8')

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -100,7 +100,7 @@ function Backup-File([string]$File, [string]$Timestamp) {
 }
 
 Write-Host ''
-Write-Host '  MixBox Studio portable setup' -ForegroundColor White
+Write-Host '  Mix Studio portable setup' -ForegroundColor White
 Write-Host '  Your gallery and settings are preserved. Setup never deletes data.' -ForegroundColor DarkGray
 
 Write-Step 'Checking the portable checkout'
@@ -231,14 +231,14 @@ try {
   Invoke-RestMethod -Uri $ObjectInfoUrl -Method Get -TimeoutSec 5 | Out-Null
   Write-Host 'ComfyUI is reachable.' -ForegroundColor Green
 } catch {
-  Write-Host 'ComfyUI is not reachable yet. Start it, then use Advanced Settings in MixBox Studio to test again.' -ForegroundColor Yellow
+  Write-Host 'ComfyUI is not reachable yet. Start it, then use Advanced Settings in Mix Studio to test again.' -ForegroundColor Yellow
 }
 
 Write-Host ''
 Write-Host 'Setup complete.' -ForegroundColor Green
-Write-Host 'Use start.bat to launch MixBox Studio. The in-app Update button pulls this Git branch.'
+Write-Host 'Use start.bat to launch Mix Studio. The in-app Update button pulls this Git branch.'
 Write-Host 'Existing model files are reused in place; setup does not copy or redownload them.'
 
-if (-not $SkipLaunch -and (Read-YesNo 'Start MixBox Studio now?' $true)) {
+if (-not $SkipLaunch -and (Read-YesNo 'Start Mix Studio now?' $true)) {
   Start-Process (Join-Path $Root 'start.bat') -WorkingDirectory $Root
 }

--- a/installer/uninstall.ps1
+++ b/installer/uninstall.ps1
@@ -48,7 +48,7 @@ function Assert-SafeInstallRoot {
   }
   if (-not (Test-Path (Join-Path $Root 'server.js')) -or
       -not (Test-Path (Join-Path $Root 'installer\uninstall.ps1'))) {
-    throw "This does not look like a MixBox Studio checkout: $RootFull"
+    throw "This does not look like a Mix Studio checkout: $RootFull"
   }
 }
 
@@ -79,12 +79,12 @@ $Install = Read-JsonObject $InstallFile
 $AppId = [string](Property-Or $Install 'appId' '')
 $InstallMode = [string](Property-Or $Install 'installMode' '')
 if ($AppId -and $AppId -ne 'mixbox-studio') { throw "This checkout belongs to another application ($AppId). Nothing was changed." }
-if ($InstallMode -and $InstallMode -ne 'portable') { throw "This is not a portable MixBox Studio install. Nothing was changed." }
+if ($InstallMode -and $InstallMode -ne 'portable') { throw "This is not a portable Mix Studio install. Nothing was changed." }
 if ($RemoveData -and $KeepData) { throw 'Choose either -RemoveData or -KeepData, not both.' }
 
 $PreserveData = -not $RemoveData
 Write-Host ''
-Write-Host '  MixBox Studio uninstaller' -ForegroundColor White
+Write-Host '  Mix Studio uninstaller' -ForegroundColor White
 Write-Host '  ComfyUI, shared models, and Node.js are never removed by this tool.' -ForegroundColor DarkGray
 Write-Host "  Application folder: $Root" -ForegroundColor DarkGray
 if (Test-Path $LocalData) {
@@ -99,7 +99,7 @@ if (Test-Path $LocalData) {
 
 if (-not $NonInteractive) {
   if ($PreserveData) {
-    if (-not (Read-YesNo 'Remove MixBox Studio but keep the local data folder?' $true)) { Write-Host 'Cancelled.'; exit 0 }
+    if (-not (Read-YesNo 'Remove Mix Studio but keep the local data folder?' $true)) { Write-Host 'Cancelled.'; exit 0 }
   } else {
     Write-Host 'This permanently deletes the local data folder, including profiles and gallery media.' -ForegroundColor Red
     $Confirmation = Read-Host 'Type DELETE to continue'
@@ -109,7 +109,7 @@ if (-not $NonInteractive) {
   throw 'Non-interactive uninstall requires -Force.'
 }
 
-Write-Host 'Uninstall is scheduled. Close MixBox Studio before the cleanup runs.' -ForegroundColor Yellow
+Write-Host 'Uninstall is scheduled. Close Mix Studio before the cleanup runs.' -ForegroundColor Yellow
 Start-Cleanup $PreserveData
 if ($PreserveData) {
   Write-Host "The data folder will remain at $LocalData." -ForegroundColor Green

--- a/public/app.js
+++ b/public/app.js
@@ -5486,6 +5486,7 @@ function setGenerating(on, statusText) {
 
 state.queueProgress = {};
 let queueRefreshAt = 0;
+let queueDrag = null;
 
 async function refreshQueue() {
   const q = await api('/api/queue');
@@ -5543,8 +5544,156 @@ function openFromQueue(itemId, videoId) {
   if (state.items.some((i) => i.id === itemId)) go();
   else refreshGallery(true).then(go);
 }
+
+function queueReorderRows() {
+  return [...document.querySelectorAll('#queueList .queue-row[data-reorderable="true"]')];
+}
+
+function clearQueueDragClasses() {
+  document.querySelectorAll('#queueList .queue-drag-over-before, #queueList .queue-drag-over-after')
+    .forEach((row) => row.classList.remove('queue-drag-over-before', 'queue-drag-over-after'));
+}
+
+function cancelQueueDrag(gesture) {
+  if (!gesture || queueDrag !== gesture) return;
+  clearTimeout(gesture.timer);
+  try { gesture.row.releasePointerCapture(gesture.pointerId); } catch { /* noop */ }
+  if (gesture.ghost) gesture.ghost.remove();
+  gesture.row.classList.remove('queue-drag-source');
+  clearQueueDragClasses();
+  queueDrag = null;
+}
+
+function updateQueueDragTarget(gesture, clientY) {
+  clearQueueDragClasses();
+  const target = queueReorderRows().find((row) => {
+    if (row === gesture.row) return false;
+    const rect = row.getBoundingClientRect();
+    return clientY >= rect.top && clientY <= rect.bottom;
+  });
+  if (!target) {
+    gesture.target = null;
+    return;
+  }
+  const rect = target.getBoundingClientRect();
+  const before = clientY < rect.top + rect.height / 2;
+  gesture.target = { row: target, before };
+  target.classList.add(before ? 'queue-drag-over-before' : 'queue-drag-over-after');
+}
+
+function beginQueueDrag(gesture) {
+  if (!gesture || queueDrag !== gesture || gesture.active) return;
+  gesture.active = true;
+  gesture.row.classList.add('queue-drag-source');
+  const rect = gesture.row.getBoundingClientRect();
+  const ghost = gesture.row.cloneNode(true);
+  ghost.classList.add('queue-drag-ghost', 'queue-drag-ghost-lifted');
+  ghost.style.width = `${rect.width}px`;
+  ghost.style.left = `${rect.left}px`;
+  ghost.style.top = `${rect.top}px`;
+  document.body.appendChild(ghost);
+  gesture.ghost = ghost;
+}
+
+function finishQueueDrag(gesture, clientY) {
+  if (!gesture || queueDrag !== gesture) return;
+  if (!gesture.active) return cancelQueueDrag(gesture);
+  updateQueueDragTarget(gesture, clientY);
+  const rows = queueReorderRows();
+  const target = gesture.target;
+  const current = rows.map((row) => row.dataset.jobId);
+  const sourceIndex = current.indexOf(gesture.jobId);
+  let order = current.slice();
+  if (target && sourceIndex !== -1) {
+    order.splice(sourceIndex, 1);
+    let targetIndex = order.indexOf(target.row.dataset.jobId);
+    if (targetIndex !== -1 && !target.before) targetIndex += 1;
+    order.splice(Math.max(0, targetIndex), 0, gesture.jobId);
+  }
+  gesture.row.dataset.queueDragged = 'true';
+  setTimeout(() => gesture.row.removeAttribute('data-queue-dragged'), 0);
+  cancelQueueDrag(gesture);
+  if (order.join('|') === current.join('|')) return;
+  const rowById = new Map(rows.map((row) => [row.dataset.jobId, row]));
+  const fragment = document.createDocumentFragment();
+  order.forEach((id) => fragment.appendChild(rowById.get(id)));
+  $('#queueList').insertBefore(fragment, $('#queueList').firstElementChild);
+  submitQueueReorder(order);
+}
+
+function attachQueueDrag(row, job) {
+  let gesture = null;
+  row.dataset.reorderable = 'true';
+  row.addEventListener('pointerdown', (event) => {
+    if (event.button !== undefined && event.button !== 0) return;
+    if (event.target.closest('button, a, input, select, textarea')) return;
+    if (queueDrag) return;
+    gesture = {
+      row,
+      jobId: job.jobId,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      active: false,
+      timer: setTimeout(() => beginQueueDrag(gesture), 180),
+      ghost: null,
+      target: null,
+    };
+    queueDrag = gesture;
+    try { row.setPointerCapture(event.pointerId); } catch { /* noop */ }
+  });
+  row.addEventListener('pointermove', (event) => {
+    if (!gesture || queueDrag !== gesture || event.pointerId !== gesture.pointerId) return;
+    if (!gesture.active) {
+      if (Math.hypot(event.clientX - gesture.startX, event.clientY - gesture.startY) > 8) cancelQueueDrag(gesture);
+      return;
+    }
+    if (gesture.ghost) gesture.ghost.style.transform = `translate3d(0, ${event.clientY - gesture.startY}px, 0)`;
+    updateQueueDragTarget(gesture, event.clientY);
+  });
+  row.addEventListener('pointerup', (event) => {
+    if (gesture && event.pointerId === gesture.pointerId) finishQueueDrag(gesture, event.clientY);
+  });
+  row.addEventListener('pointercancel', () => cancelQueueDrag(gesture));
+}
+
+function applyQueueJobMapping(mapping) {
+  for (const [oldId, newId] of Object.entries(mapping || {})) {
+    if (state.activeJobs.has(oldId)) {
+      state.activeJobs.delete(oldId);
+      state.activeJobs.add(newId);
+    }
+    if (state.queueProgress[oldId] != null) {
+      state.queueProgress[newId] = state.queueProgress[oldId];
+      delete state.queueProgress[oldId];
+    }
+    const composite = state.compositeJobs.get(oldId);
+    if (composite) {
+      state.compositeJobs.delete(oldId);
+      state.compositeJobs.set(newId, composite);
+    }
+  }
+}
+
+async function submitQueueReorder(order) {
+  try {
+    const result = await api('/api/queue/reorder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order }),
+    });
+    applyQueueJobMapping(result.mapping);
+    toast('Queue order updated');
+    await refreshQueue();
+  } catch (error) {
+    toast(error.message, true);
+    try { await refreshQueue(); } catch { /* noop */ }
+  }
+}
+
 function renderQueue(q) {
   renderQueueHealth(q.health);
+  if (queueDrag) return;
   const list = $('#queueList');
   list.innerHTML = '';
   const rows = [
@@ -5554,9 +5703,16 @@ function renderQueue(q) {
   if (!rows.length) {
     list.innerHTML = '<div class="queue-empty">Queue is empty — nothing running.</div>';
   }
+  const pending = q.pending || [];
+  const canReorder = pending.length > 1 && pending.every((job) => job.reorderable === true);
+  const hint = $('#queueReorderHint');
+  if (hint) hint.hidden = !canReorder;
+  const clearHistory = $('#queueClearHistoryBtn');
+  if (clearHistory) clearHistory.disabled = !(q.history || []).length;
   for (const j of rows) {
     const row = document.createElement('div');
     row.className = 'queue-row';
+    row.dataset.jobId = j.jobId;
     const st = document.createElement('span');
     st.className = 'q-state' + (j.run ? ' run' : '');
     st.dataset.jobId = j.jobId;
@@ -5568,7 +5724,12 @@ function renderQueue(q) {
     lb.textContent = elapsed ? `${j.label} - ${elapsed}` : j.label;
     if (j.itemId) {
       row.classList.add('q-click');
-      lb.addEventListener('click', () => openFromQueue(j.itemId));
+      row.title = 'Open in Library';
+      row.addEventListener('click', (event) => {
+        if (event.target.closest('button, a')) return;
+        if (row.dataset.queueDragged === 'true') return;
+        openFromQueue(j.itemId, j.videoId);
+      });
     }
     const x = document.createElement('button');
     x.className = 'q-cancel';
@@ -5586,7 +5747,16 @@ function renderQueue(q) {
         refreshQueue();
       } catch (e2) { toast(e2.message, true); }
     });
-    row.append(st, lb, x);
+    if (!j.run && canReorder) {
+      const handle = document.createElement('span');
+      handle.className = 'q-handle';
+      handle.textContent = '⋮⋮';
+      handle.setAttribute('aria-hidden', 'true');
+      row.append(handle, st, lb, x);
+      attachQueueDrag(row, j);
+    } else {
+      row.append(st, lb, x);
+    }
     list.appendChild(row);
   }
   // Recent generations (history)
@@ -5635,6 +5805,21 @@ $('#queueResetBtn').addEventListener('click', async () => {
   } catch (e) {
     toast(e.message, true);
   } finally {
+    btn.disabled = false;
+  }
+});
+
+$('#queueClearHistoryBtn').addEventListener('click', async () => {
+  const btn = $('#queueClearHistoryBtn');
+  if (btn.disabled) return;
+  if (!window.confirm('Clear recent queue history? Gallery items will not be deleted.')) return;
+  btn.disabled = true;
+  try {
+    const result = await api('/api/queue/history/clear', { method: 'POST' });
+    toast(`${result.cleared || 0} history item${result.cleared === 1 ? '' : 's'} cleared`);
+    await refreshQueue();
+  } catch (error) {
+    toast(error.message, true);
     btn.disabled = false;
   }
 });

--- a/public/app.js
+++ b/public/app.js
@@ -95,6 +95,7 @@ const state = {
   animateTarget: null,
   animateRouteTarget: null,
   currentItem: null,
+  currentMedia: null,
   upscaleTarget: null,
   moveTarget: null,
   selectMode: false,
@@ -6205,6 +6206,16 @@ function galleryImageModelLabel(item) {
   return '';
 }
 
+function galleryCardModelLabel(item) {
+  if (!item) return '';
+  if (item.mode === 't2i') return item.krea2Turbo === false ? 'Raw' : 'Turbo';
+  return galleryImageModelLabel(item);
+}
+
+function itemHasLike(item) {
+  return !!(item && (item.liked || (item.videos || []).some((video) => video && video.liked)));
+}
+
 function latestGalleryVideo(item) {
   const videos = Array.isArray(item && item.videos) ? item.videos : [];
   return videos.reduce((newest, video) => {
@@ -6244,14 +6255,26 @@ function matchesLibrarySearch(it, query) {
 }
 
 function visibleItems() {
-  const arr = state.items.filter((it) => {
+  const eligible = state.items.filter((it) => {
     if (state.activeFolder !== 'all' && it.folder !== state.activeFolder) return false;
-    if (state.likesOnly && !it.liked) return false;
     const hasVideos = it.videos && it.videos.length;
     if (state.mediaFilter === 'videos' && !hasVideos) return false;
     if (state.mediaFilter === 'images' && hasVideos) return false;
     return matchesLibrarySearch(it, state.libraryQuery);
   });
+  let arr = eligible.filter((it) => {
+    if (state.likesOnly && !it.liked) {
+      const videoLiked = (it.videos || []).some((video) => video && video.liked);
+      if (!videoLiked) return false;
+    }
+    return true;
+  });
+  if (state.likesOnly) {
+    const likedAngleGroups = new Set(arr.map((it) => it.angleGroupId).filter(Boolean));
+    if (likedAngleGroups.size) {
+      arr = eligible.filter((it) => !it.angleGroupId || likedAngleGroups.has(it.angleGroupId));
+    }
+  }
   if (state.sortMode === 'old') arr.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
   else if (state.sortMode === 'az') arr.sort((a, b) => (a.prompt || '').localeCompare(b.prompt || ''));
   else if (state.sortMode === 'active') arr.sort((a, b) => itemActivity(b) - itemActivity(a));
@@ -6354,8 +6377,34 @@ function addGalleryDuration(badge, durationMs, standalone = false) {
   badge.appendChild(duration);
 }
 
+let galleryPreviewObserver = null;
+function galleryPreviewMotionAllowed() {
+  return document.visibilityState === 'visible'
+    && !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+function ensureGalleryPreviewObserver() {
+  if (galleryPreviewObserver || !('IntersectionObserver' in window)) return;
+  galleryPreviewObserver = new IntersectionObserver((entries) => {
+    entries.forEach(({ target, isIntersecting }) => {
+      if (isIntersecting && galleryPreviewMotionAllowed()) {
+        target.play().catch(() => { /* autoplay may be blocked */ });
+      } else {
+        target.pause();
+        try { target.currentTime = 0; } catch { /* noop */ }
+      }
+    });
+  }, { root: null, rootMargin: '-24% 0px -24% 0px', threshold: 0.05 });
+}
+function resetGalleryPreviewObservation() {
+  if (!galleryPreviewObserver) return;
+  galleryPreviewObserver.disconnect();
+  $$('.gallery-card-video').forEach((video) => galleryPreviewObserver.observe(video));
+}
+
 function renderGrid() {
   const grid = $('#galleryGrid');
+  ensureGalleryPreviewObserver();
+  if (galleryPreviewObserver) galleryPreviewObserver.disconnect();
   grid.innerHTML = '';
   const items = visibleItems();
   const entries = galleryEntries(items);
@@ -6378,18 +6427,36 @@ function renderGrid() {
       grid.appendChild(divider);
     }
     const card = document.createElement('button');
-    card.className = 'card' + (entry.angleGroupId ? ' angle-group' : '');
-    const img = document.createElement('img');
-    img.loading = 'lazy';
-    img.src = '/images/' + it.file;
-    card.appendChild(img);
+    const hasAttachedComposite = Array.isArray(it.composites) && it.composites.length > 0;
+    card.className = 'card'
+      + (entry.angleGroupId ? ' angle-group' : '')
+      + (hasAttachedComposite ? ' has-attached-composite' : '');
+    const latestVideo = latestGalleryVideo(it);
+    if (latestVideo) {
+      const preview = document.createElement('video');
+      preview.className = 'gallery-card-video';
+      preview.muted = true;
+      preview.loop = true;
+      preview.playsInline = true;
+      preview.preload = 'metadata';
+      preview.poster = '/images/' + it.file;
+      preview.src = '/videos/' + latestVideo.file;
+      preview.tabIndex = -1;
+      preview.setAttribute('aria-hidden', 'true');
+      card.appendChild(preview);
+    } else {
+      const img = document.createElement('img');
+      img.loading = 'lazy';
+      img.src = '/images/' + it.file;
+      card.appendChild(img);
+    }
     const cardDuration = galleryItemDurationMs(it);
-    const imageModel = galleryImageModelLabel(it);
+    const imageModel = galleryCardModelLabel(it);
     if (imageModel) {
       const model = document.createElement('span');
       model.className = 'badge model-badge' + (it.upscaled ? ' up' : '');
       model.textContent = `${it.upscaled ? '↑ ' : ''}${imageModel}`;
-      model.title = `${it.upscaled ? 'Upscaled · ' : ''}Image model: ${imageModel}`;
+      model.title = `${it.upscaled ? 'Upscaled · ' : ''}Image model: ${galleryImageModelLabel(it)}`;
       if (!(it.videos && it.videos.length)) addGalleryDuration(model, cardDuration);
       card.appendChild(model);
     }
@@ -6398,7 +6465,7 @@ function renderGrid() {
       const videoModel = videoEngineLabel(latestVideo && latestVideo.info && latestVideo.info.engine);
       const v = document.createElement('span');
       v.className = 'badge vid';
-      v.textContent = it.videos.length > 1 ? `▶ ${videoModel} +${it.videos.length - 1}` : `▶ ${videoModel}`;
+      v.textContent = `▶ ${videoModel}`;
       v.title = `Video model: ${videoModel}`;
       addGalleryDuration(v, cardDuration);
       card.appendChild(v);
@@ -6415,21 +6482,23 @@ function renderGrid() {
       addGalleryDuration(b, cardDuration, true);
       card.appendChild(b);
     }
-    if (Array.isArray(it.composites) && it.composites.length) {
+    if (hasAttachedComposite) {
       const b = document.createElement('span');
       b.className = 'badge attached-composite-badge';
       b.textContent = 'Before + after';
       card.appendChild(b);
     }
-    if (entry.angleGroupId) {
+    const groupCount = entry.angleGroupId && entry.items.length > 1
+      ? entry.items.length
+      : (it.videos && it.videos.length > 1 ? it.videos.length : 0);
+    if (groupCount) {
       const badge = document.createElement('span');
-      badge.className = 'badge angle-group-badge';
-      badge.title = `${entry.items.length} camera angles`;
-      badge.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m12 2 8 4.5v9L12 20l-8-4.5v-9L12 2Zm0 2.1L6.1 7.4 12 10.7l5.9-3.3L12 4.1Zm-6 5v5.1l5 2.8v-5.2L6 9.2Zm7 7.9 5-2.8V9.2l-5 2.5v5.4Z"/></svg><b>'
-        + entry.items.length + '</b>';
+      badge.className = 'badge generation-count-badge' + (entry.angleGroupId ? ' angle-group-badge' : '');
+      badge.textContent = String(groupCount);
+      badge.title = `${groupCount} generations grouped`;
       card.appendChild(badge);
     }
-    if (it.liked) {
+    if (entry.items.some(itemHasLike)) {
       const badge = document.createElement('span');
       badge.className = 'badge liked-badge';
       badge.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 20.5 4.5 13A5.15 5.15 0 0 1 12 5.95 5.15 5.15 0 0 1 19.5 13L12 20.5Z"/></svg>';
@@ -6442,6 +6511,7 @@ function renderGrid() {
       card.appendChild(ov);
     }
     card.dataset.id = it.id;
+    card.dataset.media = latestVideo ? latestVideo.id : 'image';
     if (state.selected.has(it.id)) card.classList.add('selected');
 
     // long-press -> multi-select mode; tap -> toggle (in select mode) or open
@@ -6489,7 +6559,20 @@ function renderGrid() {
     });
     grid.appendChild(card);
   }
+  resetGalleryPreviewObservation();
 }
+
+document.addEventListener('visibilitychange', () => {
+  const previews = $$('.gallery-card-video');
+  if (document.hidden || !galleryPreviewMotionAllowed()) {
+    previews.forEach((video) => {
+      video.pause();
+      try { video.currentTime = 0; } catch { /* noop */ }
+    });
+  } else {
+    resetGalleryPreviewObservation();
+  }
+});
 
 let galleryTap = null;
 let lightboxTap = null;
@@ -6511,8 +6594,7 @@ function playLikeBurst(target, mode = 'like') {
 
 async function setItemLiked(item, liked, burstTarget) {
   if (!item) return;
-  const items = angleGroupItems(item);
-  const targets = items.length > 1 ? items : [item];
+  const targets = [item];
   if (targets.some((target) => target._likePending)) return;
   const previous = targets.map((target) => !!target.liked);
   targets.forEach((target) => {
@@ -6537,6 +6619,29 @@ async function setItemLiked(item, liked, burstTarget) {
   }
 }
 
+async function setVideoLiked(item, video, liked, burstTarget) {
+  if (!item || !video || video._likePending) return;
+  const previous = !!video.liked;
+  video.liked = liked;
+  video._likePending = true;
+  playLikeBurst(burstTarget, liked ? 'like' : 'unlike');
+  try {
+    const updated = await api(`/api/item/${item.id}/video/${video.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ liked }),
+    });
+    Object.assign(item, updated);
+    if (state.currentItem && state.currentItem.id === item.id) openLightbox(item.id, video.id);
+  } catch (error) {
+    video.liked = previous;
+    toast(error.message, true);
+  } finally {
+    video._likePending = false;
+  }
+  setTimeout(renderGrid, liked ? 720 : 520);
+}
+
 function toggleItemLike(item, burstTarget) {
   setItemLiked(item, !item.liked, burstTarget);
 }
@@ -6556,7 +6661,7 @@ function handleGalleryTap(item, card) {
     timer: setTimeout(() => {
       if (galleryTap && galleryTap.itemId === item.id) {
         galleryTap = null;
-        openLightbox(item.id);
+        openLightbox(item.id, card.dataset.media || 'image');
       }
     }, 260),
   };
@@ -6565,14 +6670,21 @@ function handleGalleryTap(item, card) {
 function handleLightboxTap() {
   const item = state.currentItem;
   if (!item) return;
+  const selectedVideo = state.currentMedia && state.currentMedia.type === 'video'
+    ? (item.videos || []).find((video) => video.id === state.currentMedia.id)
+    : null;
+  const mediaId = selectedVideo ? selectedVideo.id : 'image';
   const now = Date.now();
-  if (lightboxTap && lightboxTap.itemId === item.id && now - lightboxTap.time < 300) {
+  if (lightboxTap && lightboxTap.itemId === item.id && lightboxTap.mediaId === mediaId && now - lightboxTap.time < 300) {
     lightboxTap = null;
-    toggleItemLike(item, $('#lightboxLikeBurst'));
+    if (selectedVideo) setVideoLiked(item, selectedVideo, !selectedVideo.liked, $('#lightboxLikeBurst'));
+    else toggleItemLike(item, $('#lightboxLikeBurst'));
     return;
   }
-  lightboxTap = { itemId: item.id, time: now };
-  setTimeout(() => { if (lightboxTap && lightboxTap.itemId === item.id) lightboxTap = null; }, 320);
+  lightboxTap = { itemId: item.id, mediaId, time: now };
+  setTimeout(() => {
+    if (lightboxTap && lightboxTap.itemId === item.id && lightboxTap.mediaId === mediaId) lightboxTap = null;
+  }, 320);
 }
 
 function updateLibrarySearch() {
@@ -6709,6 +6821,8 @@ function openLightbox(id, mediaSel) {
   if (sel !== 'image' && !videos.some((v) => v.id === sel) && !composites.some((composite) => 'composite:' + composite.id === sel)) sel = 'image';
   const selVideo = videos.find((v) => v.id === sel) || null;
   const selComposite = composites.find((composite) => 'composite:' + composite.id === sel) || null;
+  state.currentMedia = selVideo ? { type: 'video', id: selVideo.id }
+    : (selComposite ? { type: 'composite', id: selComposite.id } : { type: 'image', id: 'image' });
   $('#lightbox').classList.add('show');
 
   const vid = $('#lbVideo');
@@ -6746,16 +6860,16 @@ function openLightbox(id, mediaSel) {
     });
   }
   if (videos.length || composites.length) {
-    const mkChip = (label, key) => {
+    const mkChip = (label, key, liked = false) => {
       const b = document.createElement('button');
       b.className = 'chip' + ((key === 'image' ? (!selVideo && !selComposite) : (selVideo && selVideo.id === key) || (selComposite && 'composite:' + selComposite.id === key)) ? ' active' : '');
-      b.textContent = label;
+      b.innerHTML = `<span>${escapeHtml(label)}</span>${liked ? '<span class="lb-media-like" aria-label="Liked">♥</span>' : ''}`;
       b.addEventListener('click', () => openLightbox(id, key));
       mrow.appendChild(b);
     };
-    mkChip('🖼 Image', 'image');
-    composites.forEach((composite) => mkChip('▣ ' + (composite.label || 'Before + after'), 'composite:' + composite.id));
-    videos.forEach((v, i) => mkChip('▶ ' + (i + 1), v.id));
+    mkChip('Image', 'image', !!it.liked);
+    composites.forEach((composite) => mkChip(composite.label || 'Before + after', 'composite:' + composite.id));
+    videos.forEach((v, i) => mkChip(`Video ${i + 1}`, v.id, !!v.liked));
   }
 
   const meta = [];
@@ -6856,9 +6970,14 @@ function openLightbox(id, mediaSel) {
   } else if (it.mode !== 'composite') {
     mk(videos.length ? '🎬 Animate again' : '🎬 Animate', 'primary', () => openAnimateRouteSheet(it));
   }
-  if ((!selVideo && !selComposite) || videos.length) {
-    const like = mkIcon(it.liked ? 'heart-fill' : 'heart', it.liked ? 'Unlike' : 'Like', `like-toggle${it.liked ? ' liked' : ''}`, () => toggleItemLike(it, $('#lightboxLikeBurst')));
-    like.setAttribute('aria-pressed', String(!!it.liked));
+  if (!selComposite) {
+    const liked = selVideo ? !!selVideo.liked : !!it.liked;
+    const label = selVideo ? (liked ? 'Unlike video' : 'Like video') : (liked ? 'Unlike' : 'Like');
+    const like = mkIcon(liked ? 'heart-fill' : 'heart', label, `like-toggle${liked ? ' liked' : ''}`, () => {
+      if (selVideo) setVideoLiked(it, selVideo, !selVideo.liked, $('#lightboxLikeBurst'));
+      else toggleItemLike(it, $('#lightboxLikeBurst'));
+    });
+    like.setAttribute('aria-pressed', String(liked));
   }
   // Reference-backed generations: hold to flash the retained source image.
   if (sourceReference) {
@@ -7032,6 +7151,7 @@ function closeLightbox(fromPop) {
   const vid = $('#lbVideo');
   try { vid.pause(); } catch { /* noop */ }
   state.currentItem = null;
+  state.currentMedia = null;
   unlockScroll();
   if (!fromPop && window.history.state && window.history.state.lb) {
     try { history.back(); } catch { /* noop */ }

--- a/public/app.js
+++ b/public/app.js
@@ -630,6 +630,11 @@ function actionIconMarkup(icon) {
     motion: '<path d="M4 7h8V5l4 3-4 3V9H4V7Zm16 8H12v-2l-4 3 4 3v-2h8v-2Z"/>',
     'first-frame': '<path d="M5 5h15v14H5V5Zm2 2v10h11V7H7Zm-5 4h2v2H2v-2Zm7 4 2.7-3.2 2 2.1 1.5-1.8L17 15H9Z"/>',
     'last-frame': '<path d="M4 5h15v14H4V5Zm2 2v10h11V7H6Zm14 4h2v2h-2v-2ZM8 15l2.7-3.2 2 2.1 1.5-1.8L17 15H8Z"/>',
+    save: '<path d="M5 3h12l3 3v15H4V3h1Zm1 2v14h12V6.8L16.2 5H6Zm2 0h6v5H8V5Zm1 10h6v4H9v-4Z"/>',
+    composite: '<path d="M5 5h11v11H5V5Zm2 2v7h7V7H7Zm6 4h6v8H9v-3h2v1h6v-4h-4v-2Z"/>',
+    process: '<path d="M4 7h10v2H4V7Zm13-1h3v4h-3V6ZM4 15h6v2H4v-2Zm9-1h3v4h-3v-4Zm-3-4h10v2H10v-2Z"/>',
+    heart: '<path d="M12 20.7 4.4 13A5.2 5.2 0 0 1 12 6a5.2 5.2 0 0 1 7.6 7L12 20.7Zm0-2.8 6.1-6.2a3.2 3.2 0 0 0-4.5-4.5L12 8.8l-1.6-1.6a3.2 3.2 0 0 0-4.5 4.5L12 17.9Z"/>',
+    'heart-fill': '<path d="M12 21 3.9 12.9A5.6 5.6 0 0 1 12 5.15a5.6 5.6 0 0 1 8.1 7.75L12 21Z"/>',
   };
   return `<svg class="action-glyph" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">${paths[icon] || paths.use}</svg>`;
 }
@@ -6813,10 +6818,38 @@ function openLightbox(id, mediaSel) {
       const list = typeof items === 'function' ? items() : items;
       openActionMenu(b, list || [], options);
     };
-    b = options.icon ? mkIcon(options.icon, options.ariaLabel || label, cls, onOpen) : mk(label, cls, onOpen);
+    b = options.icon
+      ? mk(`${actionIconMarkup(options.icon)}<span>${escapeHtml(label)}</span>`, `menu-trigger ${cls || ''}`.trim(), onOpen, { ariaLabel: options.ariaLabel || label, title: options.ariaLabel || label })
+      : mk(label, cls, onOpen);
     if (options.icon) b.setAttribute('aria-haspopup', 'menu');
     return b;
   };
+
+  const sourceReference = !selVideo && !selComposite && it.sourceFile
+    && (it.mode === 'edit' || it.mode === 't2i');
+  const isEditSource = sourceReference && it.mode === 'edit';
+  const imageSaveItems = [];
+  if (!selVideo && !selComposite) {
+    if (it.upscaled) {
+      imageSaveItems.push(
+        { label: 'Save upscaled', detail: 'Current image', icon: 'save', action: () => downloadItem(it, 'upscaled') },
+        { label: 'Save original', detail: 'Before upscale', icon: 'save', action: () => downloadItem(it, 'original') },
+      );
+    } else {
+      imageSaveItems.push({ label: 'Save image', icon: 'save', action: () => downloadItem(it, 'current') });
+    }
+    if (angleItems.length > 1) {
+      imageSaveItems.push({ label: 'Save angle composite', detail: 'All camera views', icon: 'composite', action: () => saveImageComposite(it, 'angles') });
+    }
+    if (sourceReference) {
+      imageSaveItems.push({
+        label: isEditSource ? 'Save before + after' : 'Save reference + generation',
+        detail: isEditSource ? 'Original and edited image' : 'Reference and generated image',
+        icon: 'composite',
+        action: () => saveImageComposite(it, isEditSource ? 'before-after' : 'reference-generation'),
+      });
+    }
+  }
 
   if (state.animating.has(it.id)) {
     mk('<span class="spin"></span> Animating…', selVideo ? 'primary' : '', () => {});
@@ -6824,16 +6857,11 @@ function openLightbox(id, mediaSel) {
     mk(videos.length ? '🎬 Animate again' : '🎬 Animate', 'primary', () => openAnimateRouteSheet(it));
   }
   if ((!selVideo && !selComposite) || videos.length) {
-    mk(it.liked ? '♥ Liked' : '♡ Like', it.liked ? 'primary' : '', () => toggleItemLike(it, $('#lightboxLikeBurst')));
-  }
-  if (!selVideo && !selComposite && angleItems.length > 1) {
-    mk('▦ Save angle composite', '', () => saveImageComposite(it, 'angles'));
+    const like = mkIcon(it.liked ? 'heart-fill' : 'heart', it.liked ? 'Unlike' : 'Like', `like-toggle${it.liked ? ' liked' : ''}`, () => toggleItemLike(it, $('#lightboxLikeBurst')));
+    like.setAttribute('aria-pressed', String(!!it.liked));
   }
   // Reference-backed generations: hold to flash the retained source image.
-  const sourceReference = !selVideo && !selComposite && it.sourceFile
-    && (it.mode === 'edit' || it.mode === 't2i');
   if (sourceReference) {
-    const isEditSource = it.mode === 'edit';
     const hb = mk(isEditSource ? '👁 Hold: original' : '👁 Hold: reference', '', () => {});
     hb.style.userSelect = 'none';
     hb.style.webkitUserSelect = 'none';
@@ -6844,9 +6872,6 @@ function openLightbox(id, mediaSel) {
     hb.addEventListener('pointercancel', hide);
     hb.addEventListener('pointerleave', hide);
     hb.addEventListener('contextmenu', (e) => e.preventDefault());
-    mk(isEditSource ? '▣ Save before + after' : '▣ Save reference + generation', '', () => {
-      saveImageComposite(it, isEditSource ? 'before-after' : 'reference-generation');
-    });
   }
 
   // Region-prompted images: hold to overlay the color-coded boxes,
@@ -6924,11 +6949,11 @@ function openLightbox(id, mediaSel) {
     if (videoUseItems.length) mkMenu('Use', '', videoUseItems, { icon: 'use', ariaLabel: 'Use video', menuTitle: 'Use video', tone: 'video' });
     const processItems = [];
     if (!vinfo.composite) {
-      processItems.push({ label: 'Upscale video', action: () => processVideo(it, selVideo, 'upscale') });
-      processItems.push({ label: 'Increase FPS', action: () => processVideo(it, selVideo, 'interpolate') });
+      processItems.push({ label: 'Upscale video', detail: 'SeedVR2 finish', icon: 'process', action: () => processVideo(it, selVideo, 'upscale') });
+      processItems.push({ label: 'Increase FPS', detail: 'RIFE interpolation', icon: 'process', action: () => processVideo(it, selVideo, 'interpolate') });
     }
     if (vinfo.engine === 'scail' && vinfo.driveVideoName && !vinfo.composite) {
-      processItems.push({ label: 'Side-by-side', action: async () => {
+      processItems.push({ label: 'Side-by-side', detail: 'Reference and result', icon: 'composite', action: async () => {
         try {
           toast('Building side-by-side comparison…');
           const r = await api('/api/composite', {
@@ -6943,7 +6968,7 @@ function openLightbox(id, mediaSel) {
         } catch (e) { toast(e.message, true); }
       } });
     }
-    if (processItems.length) mkMenu('Process video', '', processItems);
+    if (processItems.length) mkMenu('Process', '', processItems, { icon: 'process', ariaLabel: 'Process video', menuTitle: 'Process video', tone: 'video' });
     mk('↓ Save video', '', () => {
       const a = document.createElement('a');
       a.href = '/videos/' + selVideo.file;
@@ -6987,13 +7012,10 @@ function openLightbox(id, mediaSel) {
     }
     mkMenu('Use', '', imageUseItems, { icon: 'use', ariaLabel: 'Use image', menuTitle: 'Use image', tone: 'image' });
     mk('▤ Move', '', () => openMoveSheet(it));
-    if (it.upscaled) {
-      mkMenu('Save', '', [
-        { label: 'Save upscaled', action: () => downloadItem(it, 'upscaled') },
-        { label: 'Save original', action: () => downloadItem(it, 'original') },
-      ]);
-    } else {
-      mk('↓ Save', '', () => downloadItem(it, 'current'));
+    if (imageSaveItems.length > 1) {
+      mkMenu('Save', '', imageSaveItems, { icon: 'save', ariaLabel: 'Save image', menuTitle: 'Save image', tone: 'image' });
+    } else if (imageSaveItems.length === 1) {
+      mk('↓ Save', '', imageSaveItems[0].action);
     }
     mk('🗑 Delete', 'danger', async () => {
       const n = videos.length;

--- a/public/index.html
+++ b/public/index.html
@@ -1113,8 +1113,10 @@
     <h3 class="sheet-title">Queue <button data-close>✕</button></h3>
     <div class="queue-health" id="queueHealth"></div>
     <div class="queue-tools">
+      <button class="queue-clear-btn" id="queueClearHistoryBtn" type="button">Clear history</button>
       <button class="queue-reset-btn" id="queueResetBtn" type="button">Hard reset</button>
     </div>
+    <div class="queue-reorder-hint" id="queueReorderHint" hidden>Hold and drag queued jobs to reorder.</div>
     <div id="queueList"></div>
   </div>
 </div>

--- a/public/style.css
+++ b/public/style.css
@@ -3234,6 +3234,23 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
   justify-content: center;
   padding: 0;
 }
+.action-btn.menu-trigger {
+  min-height: 42px;
+  padding: 9px 13px;
+}
+.action-btn.menu-trigger .action-glyph { width: 17px; height: 17px; }
+.action-btn.like-toggle {
+  width: 42px;
+  height: 42px;
+  border-color: rgba(255,255,255,0.18);
+  color: rgba(255,255,255,0.9);
+}
+.action-btn.like-toggle.liked {
+  color: #fff;
+  border-color: rgba(255,255,255,0.54);
+  background: rgba(255,255,255,0.11);
+}
+.action-btn.like-toggle .action-glyph { width: 19px; height: 19px; }
 .action-glyph { width: 18px; height: 18px; display: block; }
 .action-btn.icon-only .action-glyph { width: 19px; height: 19px; }
 .action-menu {

--- a/public/style.css
+++ b/public/style.css
@@ -3010,7 +3010,14 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
   background: var(--panel-strong);
   padding: 0;
 }
-.card img { display: block; width: 100%; aspect-ratio: 1; object-fit: cover; }
+.card img,
+.card .gallery-card-video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  background: #050609;
+}
 .card .badge {
   position: absolute; top: 8px; left: 8px;
   font-size: 9.5px; font-weight: 900; letter-spacing: 0.1em; text-transform: uppercase;
@@ -3044,9 +3051,10 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 }
 .card .badge.model-badge.up { color: #b7ffd2; }
 .card .badge.attached-composite-badge {
-  top: 8px;
-  right: 8px;
-  left: auto;
+  top: auto;
+  right: auto;
+  bottom: 8px;
+  left: 8px;
   color: #e5e8f1;
 }
 .card .busy-overlay {
@@ -3135,6 +3143,7 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 .lightbox-img-wrap img[hidden],
 .lightbox-img-wrap video[hidden] { display: none; }
 .card .badge.vid { top: auto; bottom: 8px; left: 8px; color: #cfe0ff; }
+.card.has-attached-composite .badge.vid { bottom: 36px; }
 .card .badge.liked-badge { top: auto; bottom: 8px; left: auto; right: 8px; padding: 5px 7px; color: #fff; }
 .liked-badge svg { display: block; width: 13px; height: 13px; }
 .like-burst {
@@ -3153,6 +3162,15 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
   align-items: center;
   gap: 4px;
   color: #eef2ff;
+}
+.card .badge.generation-count-badge {
+  top: 8px;
+  right: 8px;
+  left: auto;
+  min-width: 24px;
+  padding-left: 7px;
+  padding-right: 7px;
+  text-align: center;
 }
 .angle-group-badge svg { width: 13px; height: 13px; }
 .angle-group-badge b { font: inherit; }
@@ -3200,6 +3218,25 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 }
 .lb-media::-webkit-scrollbar { display: none; }
 .lb-media:empty { display: none; }
+.lb-media .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.035);
+  color: rgba(255,255,255,0.62);
+  font-size: 12px;
+  transition: border-color 160ms var(--ease), background 160ms var(--ease), color 160ms var(--ease);
+}
+.lb-media .chip.active {
+  border-color: rgba(148,170,220,0.62);
+  background: rgba(118,145,205,0.14);
+  color: #f4f6ff;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04);
+}
+.lb-media-like { color: #fff; font-size: 12px; line-height: 1; }
 .lightbox-meta {
   padding: 12px 18px 6px;
   font-size: 12.5px; color: var(--muted); line-height: 1.5;

--- a/public/style.css
+++ b/public/style.css
@@ -426,13 +426,44 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
   .topbar-actions { gap: 6px; }
 }
 .queue-row {
+  position: relative;
   display: flex; align-items: center; gap: 10px;
   padding: 11px 0;
   border-bottom: 1px solid rgba(226,232,255,0.06);
   font-size: 13px; font-weight: 700;
+  transition: background 150ms var(--ease), opacity 150ms var(--ease), box-shadow 150ms var(--ease);
 }
 .queue-row:last-child { border-bottom: 0; }
 .queue-row .q-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ink-soft); }
+.q-handle {
+  flex: 0 0 16px;
+  color: var(--muted-2);
+  font-size: 16px;
+  letter-spacing: -4px;
+  line-height: 1;
+  cursor: grab;
+  touch-action: none;
+}
+.queue-row[data-reorderable="true"] { touch-action: pan-y; user-select: none; }
+.queue-row[data-reorderable="true"]:active .q-handle { cursor: grabbing; }
+.queue-drag-source { opacity: 0.26; }
+.queue-drag-over-before { box-shadow: inset 0 2px 0 var(--mode-color); }
+.queue-drag-over-after { box-shadow: inset 0 -2px 0 var(--mode-color); }
+.queue-drag-ghost {
+  position: fixed;
+  z-index: 250;
+  margin: 0;
+  pointer-events: none;
+  border: 1px solid rgba(116,147,255,0.72);
+  border-radius: 12px;
+  padding-left: 10px;
+  background: rgba(15,18,29,0.94);
+  box-shadow: 0 18px 42px rgba(0,0,0,0.52), 0 0 24px rgba(66,133,244,0.24);
+  transform-origin: center;
+  transition: box-shadow 180ms var(--ease), filter 180ms var(--ease);
+  will-change: transform;
+}
+.queue-drag-ghost-lifted { filter: saturate(1.15) brightness(1.12); }
 .q-state {
   flex: 0 0 auto; width: 62px;
   font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
@@ -441,17 +472,33 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 .q-state.run { color: var(--spectrum-green); }
 .q-cancel { width: 32px; height: 32px; border-radius: 10px; border: 1px solid var(--line); background: transparent; color: var(--muted); font-weight: 900; }
 .queue-tools { display: flex; justify-content: flex-end; margin: -4px 0 8px; }
+.queue-clear-btn,
 .queue-reset-btn {
   height: 34px;
   padding: 0 12px;
   border-radius: 10px;
-  border: 1px solid rgba(234,67,53,0.45);
-  background: rgba(234,67,53,0.12);
-  color: #ffb3ad;
   font-size: 12px;
   font-weight: 900;
 }
+.queue-clear-btn {
+  margin-right: auto;
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,0.05);
+  color: var(--ink-soft);
+}
+.queue-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.queue-reset-btn {
+  border: 1px solid rgba(234,67,53,0.45);
+  background: rgba(234,67,53,0.12);
+  color: #ffb3ad;
+}
 .queue-reset-btn:active { transform: scale(0.97); }
+.queue-reorder-hint {
+  margin: -2px 0 8px;
+  color: var(--muted-2);
+  font-size: 11px;
+  font-weight: 750;
+}
 .queue-health {
   display: flex;
   flex-wrap: wrap;

--- a/server.js
+++ b/server.js
@@ -4628,6 +4628,16 @@ async function handleApi(req, res, url) {
   }
 
   const vidRoute = route.match(/^\/api\/item\/([\w]+)\/video\/([\w]+)$/);
+  if (vidRoute && req.method === 'POST') {
+    const item = db.items.find((it) => it.id === vidRoute[1] && it.profileId === req.profile.id);
+    if (!item) return json(res, 404, { error: 'Not found' });
+    const video = (item.videos || []).find((entry) => entry.id === vidRoute[2]);
+    if (!video) return json(res, 404, { error: 'Video not found' });
+    const body = await readJsonBody(req);
+    video.liked = body.liked === true;
+    saveDb();
+    return json(res, 200, item);
+  }
   if (vidRoute && req.method === 'DELETE') {
     const item = db.items.find((it) => it.id === vidRoute[1] && it.profileId === req.profile.id);
     if (!item) return json(res, 404, { error: 'Not found' });

--- a/server.js
+++ b/server.js
@@ -904,11 +904,13 @@ async function uploadToComfy(buffer, filename) {
   return (json.subfolder ? json.subfolder + '/' : '') + json.name;
 }
 
-async function queuePrompt(graph) {
+async function queuePrompt(graph, options = {}) {
+  const body = { prompt: graph, client_id: CLIENT_ID };
+  if (options.front === true) body.front = true;
   const res = await comfyFetch('/prompt', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt: graph, client_id: CLIENT_ID }),
+    body: JSON.stringify(body),
   });
   const json = await res.json();
   if (json.node_errors && Object.keys(json.node_errors).length) {
@@ -4310,8 +4312,14 @@ async function handleApi(req, res, url) {
         }
         return row;
       };
-      const running = (q.queue_running || []).map((entry) => sanitize(describeQueueEntry(entry, true)));
-      const pending = (q.queue_pending || []).map((entry) => sanitize(describeQueueEntry(entry, false)));
+      const markReorderable = (row) => {
+        const job = jobs.get(row.jobId);
+        return Object.assign(row, {
+          reorderable: !!job && job.profileId === req.profile.id && !!job.graph,
+        });
+      };
+      const running = (q.queue_running || []).map((entry) => markReorderable(sanitize(describeQueueEntry(entry, true))));
+      const pending = (q.queue_pending || []).map((entry) => markReorderable(sanitize(describeQueueEntry(entry, false))));
       return json(res, 200, {
         ok: true,
         running,
@@ -4322,6 +4330,57 @@ async function handleApi(req, res, url) {
     } catch (e) {
       return json(res, 200, { ok: false, error: String(e.message || e), running: [], pending: [] });
     }
+  }
+
+  if (route === '/api/queue/history/clear' && req.method === 'POST') {
+    const before = db.history.length;
+    db.history = db.history.filter((entry) => entry.profileId !== req.profile.id);
+    const cleared = before - db.history.length;
+    saveDb();
+    broadcast('queueHistoryCleared', { profileId: req.profile.id, cleared });
+    return json(res, 200, { ok: true, cleared });
+  }
+
+  if (route === '/api/queue/reorder' && req.method === 'POST') {
+    const body = await readJsonBody(req);
+    const order = Array.isArray(body.order) ? body.order.map((id) => String(id || '')).filter(Boolean) : [];
+    const q = await (await comfyFetch('/queue')).json();
+    const pendingIds = (q.queue_pending || []).map((entry) => String(entry && entry[1] || '')).filter(Boolean);
+    if (!pendingIds.length) return json(res, 409, { error: 'There are no queued jobs to reorder' });
+    const requestedSet = new Set(order);
+    if (order.length !== pendingIds.length || requestedSet.size !== order.length
+      || pendingIds.some((id) => !requestedSet.has(id))) {
+      return json(res, 409, { error: 'The queue changed — refresh and try again' });
+    }
+    for (const pid of order) {
+      const job = jobs.get(pid);
+      if (!job || job.profileId !== req.profile.id || !job.graph) {
+        return json(res, 409, { error: 'Only Mix Studio jobs from this profile can be reordered' });
+      }
+    }
+    await comfyFetch('/queue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ delete: pendingIds }),
+    });
+    const mapping = {};
+    try {
+      for (const oldPid of order) {
+        const job = jobs.get(oldPid);
+        const newPid = await queuePrompt(job.graph);
+        jobs.delete(oldPid);
+        jobs.set(newPid, Object.assign(job, {
+          enqueuedAt: Date.now(),
+          startedAt: null,
+          requeuedFrom: oldPid,
+        }));
+        mapping[oldPid] = newPid;
+      }
+    } catch (error) {
+      return json(res, 502, { error: `Could not rebuild the queue: ${error.message}` });
+    }
+    broadcast('queueReordered', { profileId: req.profile.id });
+    return json(res, 200, { ok: true, mapping });
   }
 
   if (route === '/api/queue/cancel' && req.method === 'POST') {

--- a/test/frontend-downloads.test.js
+++ b/test/frontend-downloads.test.js
@@ -27,6 +27,8 @@ test('lightbox groups after-the-fact video processing actions in one menu', () =
 
 test('gallery Use menus are icon-led and show concise image destinations', () => {
   assert.match(appJs, /function actionIconMarkup\(icon\)/);
+  assert.match(appJs, /menu-trigger/);
+  assert.match(appJs, /<span>\$\{escapeHtml\(label\)\}<\/span>/);
   assert.match(appJs, /menuTitle: 'Use image'/);
   assert.match(appJs, /ariaLabel: 'Use image'/);
   assert.match(appJs, /label: 'First frame', detail: 'Start a video here', icon: 'first-frame'/);

--- a/test/gallery-model-ui.test.js
+++ b/test/gallery-model-ui.test.js
@@ -31,3 +31,22 @@ test('library search includes friendly model names', () => {
   assert.match(app, /galleryImageModelLabel\(it\)/);
   assert.match(app, /\.map\(\(video\) => videoEngineLabel/);
 });
+
+test('gallery cards use compact labels, grouped counts, and middle-of-viewport video previews', () => {
+  assert.match(app, /function galleryCardModelLabel\(item\)/);
+  assert.match(app, /return item\.krea2Turbo === false \? 'Raw' : 'Turbo'/);
+  assert.match(app, /className = 'gallery-card-video'/);
+  assert.match(app, /rootMargin: '-24% 0px -24% 0px'/);
+  assert.match(app, /generation-count-badge/);
+  assert.match(app, /grouped/);
+  assert.match(css, /\.card \.badge\.attached-composite-badge[\s\S]*bottom: 8px/);
+  assert.match(css, /\.card \.gallery-card-video/);
+});
+
+test('focused media switchers use restrained active states and expose per-video likes', () => {
+  assert.match(app, /videos\.forEach\(\(v, i\) => mkChip\(`Video \$\{i \+ 1\}`, v\.id, !!v\.liked\)\)/);
+  assert.match(app, /className = 'chip' \+ /);
+  assert.match(app, /lb-media-like/);
+  assert.match(css, /\.lb-media \.chip\.active/);
+  assert.match(css, /\.lb-media-like/);
+});

--- a/test/navigation-ui.test.js
+++ b/test/navigation-ui.test.js
@@ -216,7 +216,7 @@ test('gallery saves directly when only one image is available and is grouped by 
   assert.match(css, /\.card \.badge\.attached-composite-badge/);
 });
 
-test('gallery items support profile-scoped likes by double tap and a likes-only filter', () => {
+test('gallery media supports profile-scoped likes by double tap and a likes-only filter', () => {
   const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
   assert.match(html, /id="likesFilter"[^>]*aria-pressed="false"/);
   assert.match(html, /id="lightboxLikeBurst"/);
@@ -225,7 +225,10 @@ test('gallery items support profile-scoped likes by double tap and a likes-only 
   assert.match(app, /function setItemLiked\(item, liked, burstTarget\)/);
   assert.match(app, /playLikeBurst\(burstTarget, liked \? 'like' : 'unlike'\)/);
   assert.match(app, /setTimeout\(renderGrid, liked \? 720 : 520\)/);
-  assert.match(app, /if \(state\.likesOnly && !it\.liked\) return false/);
+  assert.match(app, /if \(state\.likesOnly && !it\.liked\)/);
+  assert.match(app, /videoLiked = \(it\.videos \|\| \[\]\)\.some/);
+  assert.match(app, /function setVideoLiked\(item, video, liked, burstTarget\)/);
+  assert.match(server, /video\.liked = body\.liked === true/);
   assert.match(app, /like-toggle/);
   assert.match(app, /heart-fill/);
   assert.match(app, /Save angle composite/);

--- a/test/navigation-ui.test.js
+++ b/test/navigation-ui.test.js
@@ -179,6 +179,8 @@ test('installer-selected engines are hidden from the corresponding app controls'
 test('an edit can save its original and result as a gallery side-by-side', () => {
   const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
   assert.match(app, /Save before \+ after/);
+  assert.match(app, /const imageSaveItems = \[\]/);
+  assert.match(app, /mkMenu\('Save', '', imageSaveItems/);
   assert.match(app, /saveImageComposite\(it, isEditSource \? 'before-after' : 'reference-generation'\)/);
   assert.match(server, /type === 'before-after'/);
   assert.match(server, /sources = \[root\.sourceFile, root\.upscaled \|\| root\.file\]/);
@@ -204,7 +206,9 @@ test('image-to-image generations retain their reference for hold-preview and a g
 test('gallery saves directly when only one image is available and is grouped by date', () => {
   assert.match(app, /function galleryDateLabel\(timestamp\)/);
   assert.match(app, /gallery-date-divider/);
-  assert.match(app, /mk\('↓ Save', '', \(\) => downloadItem\(it, 'current'\)\)/);
+  assert.match(app, /imageSaveItems\.push\(\{ label: 'Save image', icon: 'save', action: \(\) => downloadItem\(it, 'current'\) \}\)/);
+  assert.match(app, /if \(imageSaveItems\.length > 1\)/);
+  assert.match(app, /mk\('↓ Save', '', imageSaveItems\[0\]\.action\)/);
   assert.match(app, /if \(it\.upscaled\) \{/);
   assert.match(app, /function downloadComposite\(it, composite\)/);
   assert.match(app, /attached-composite-badge/);
@@ -222,6 +226,8 @@ test('gallery items support profile-scoped likes by double tap and a likes-only 
   assert.match(app, /playLikeBurst\(burstTarget, liked \? 'like' : 'unlike'\)/);
   assert.match(app, /setTimeout\(renderGrid, liked \? 720 : 520\)/);
   assert.match(app, /if \(state\.likesOnly && !it\.liked\) return false/);
+  assert.match(app, /like-toggle/);
+  assert.match(app, /heart-fill/);
   assert.match(app, /Save angle composite/);
   assert.match(server, /const likeRoute = route\.match\(/);
   assert.match(server, /likeRoute && req\.method === 'POST'/);

--- a/test/portable-installer.test.js
+++ b/test/portable-installer.test.js
@@ -18,7 +18,9 @@ test('portable installer opens a branded WPF wizard instead of a terminal questi
   const ui = fs.readFileSync(path.join(root, 'installer', 'install-ui.ps1'), 'utf8');
   assert.match(ui, /PresentationFramework/);
   assert.match(ui, /Background="#000000"/);
-  assert.match(ui, /MixBox Studio/);
+  assert.match(ui, /Mix Studio/);
+  assert.match(ui, /Path Fill="#fdc302"/);
+  assert.doesNotMatch(ui, /MixBox Studio/);
   assert.match(ui, /PageWelcome/);
   assert.match(ui, /PageConnection/);
   assert.match(ui, /PageFeatures/);

--- a/test/queue-health.test.js
+++ b/test/queue-health.test.js
@@ -70,3 +70,16 @@ test('queue sheet renders health and durations', () => {
   assert.match(appJs, /formatDuration/);
   assert.match(appJs, /durationMs/);
 });
+
+test('queue sheet supports clearing history, gallery navigation, and drag reordering', () => {
+  assert.match(indexHtml, /id="queueClearHistoryBtn"/);
+  assert.match(indexHtml, /id="queueReorderHint"/);
+  assert.match(serverJs, /\/api\/queue\/history\/clear/);
+  assert.match(serverJs, /\/api\/queue\/reorder/);
+  assert.match(serverJs, /reorderable/);
+  assert.match(appJs, /openFromQueue\(j\.itemId, j\.videoId\)/);
+  assert.match(appJs, /function attachQueueDrag\(row, job\)/);
+  assert.match(appJs, /queue-drag-ghost/);
+  assert.match(appJs, /\/api\/queue\/history\/clear/);
+  assert.match(appJs, /\/api\/queue\/reorder/);
+});

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,9 +1,9 @@
 @echo off
 setlocal
-title MixBox Studio Uninstaller
+title Mix Studio Uninstaller
 cd /d "%~dp0"
 if not exist "%~dp0installer\uninstall.ps1" (
-  echo MixBox Studio Uninstaller could not find installer\uninstall.ps1.
+  echo Mix Studio Uninstaller could not find installer\uninstall.ps1.
   pause
   exit /b 1
 )


### PR DESCRIPTION
## What changed

- Add profile-scoped clearing for recent queue history without deleting gallery items.
- Open linked gallery items directly from queue and recent-history rows.
- Add hold-to-drag queue reordering with a floating mobile/desktop drag preview.
- Preserve active progress tracking when pending jobs receive new queue IDs during reorder.

## Validation

- `node --check server.js`
- `node --check public/app.js`
- `node --test` (234 passing)

Unrelated pre-existing gallery action-menu edits remain unstaged and are not included in this PR.
