### PR TITLE
Fix ComfyUI compatibility issues

### DIFF
--- a/installer/feature-manifest.json
+++ b/installer/feature-manifest.json
@@ -84,7 +84,7 @@
       "variant": "10Eros FP8 mixed; 8 GB is an experimental tier with aggressive offload",
       "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended" },
       "models": ["10eros", "ltx-dmd", "gemma-3"],
-      "nodes": ["EchoDMDSampler", "KJNodes"]
+      "nodes": ["EchoDMDSampler", "10S-Comfy-nodes", "KJNodes"]
     },
     {
       "id": "video.wan",
@@ -104,6 +104,15 @@
       "dependsOn": ["video.wan"],
       "models": ["scail2", "sam3.1", "clip-vision-h", "pusa"],
       "nodes": ["WanSCAILToVideo", "SAM3_VideoTrack", "comfyui-scail2-infinity", "ComfyUI-GGUF"]
+    },
+    {
+      "id": "video.rife",
+      "label": "RIFE Frame Interpolation",
+      "default": false,
+      "variant": "RIFE 4.x interpolation for Increase FPS",
+      "hardware": { "minimumVramGb": 4, "recommendedVramGb": 8, "autoSelect": "supported" },
+      "models": [],
+      "nodes": ["ComfyUI-Frame-Interpolation", "RIFE VFI"]
     }
   ]
 }

--- a/installer/install-dependencies.js
+++ b/installer/install-dependencies.js
@@ -119,6 +119,7 @@ async function main() {
       availableModelNames: discovery.registeredModelNames,
       availableModelRoots: discovery.modelRoots,
       modelVariants: { krea2: configuredVariant },
+      hfToken: settings.hfToken,
     },
     report(phase, message, detail = {}) {
       const progress = Number.isFinite(detail.completed) && Number.isFinite(detail.total) && detail.total > 0

--- a/installer/model-discovery.js
+++ b/installer/model-discovery.js
@@ -3,8 +3,12 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const {
+  MODEL_FILE_RE,
+  modelChoice,
+  registeredModelNames,
+} = require('../lib/model-loader');
 
-const MODEL_FILE_RE = /\.(?:safetensors|ckpt|pt|pth|bin|gguf|onnx)$/i;
 const MODEL_PATH_KEYS = new Set([
   'checkpoints', 'configs', 'vae', 'loras', 'upscale_models', 'embeddings',
   'hypernetworks', 'controlnet', 'clip', 'clip_vision', 'style_models',
@@ -20,25 +24,8 @@ function argument(argv, name) {
   return index >= 0 ? argv[index + 1] || '' : '';
 }
 
-function modelChoice(value) {
-  return typeof value === 'string' && MODEL_FILE_RE.test(value.trim());
-}
-
 function collectRegisteredModelNames(info) {
-  const names = new Set();
-  for (const cls of Object.values(info || {})) {
-    const inputs = cls && typeof cls === 'object' ? cls.input || {} : {};
-    for (const group of [inputs.required, inputs.optional]) {
-      for (const spec of Object.values(group || {})) {
-        if (!Array.isArray(spec)) continue;
-        const choices = Array.isArray(spec[0])
-          ? spec[0]
-          : (spec[0] === 'COMBO' && Array.isArray(spec[1]?.options) ? spec[1].options : []);
-        for (const choice of choices) if (modelChoice(choice)) names.add(choice.trim());
-      }
-    }
-  }
-  return [...names].sort((left, right) => left.localeCompare(right));
+  return registeredModelNames(info);
 }
 
 function stripYamlScalar(value) {

--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -10,6 +10,7 @@ const fsp = require('fs/promises');
 const path = require('path');
 const { execFile } = require('child_process');
 const { sam3InstallStatus } = require('./sam3-installer');
+const { normalizeModelPath, resolveRegisteredModelName } = require('./model-loader');
 const {
   KREA2_VARIANTS,
   krea2VariantSettings,
@@ -39,16 +40,19 @@ const NODE_PACKS = Object.freeze({
   seedvr2: { label: 'SeedVR2 Video Upscaler', folder: 'ComfyUI-SeedVR2_VideoUpscaler', repo: 'https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler.git', ref: '4490bd1f482e026674543386bb2a4d176da245b9' },
   ultimate: { label: 'Ultimate SD Upscale', folder: 'ComfyUI_UltimateSDUpscale', repo: 'https://github.com/ssitu/ComfyUI_UltimateSDUpscale.git', ref: 'a5547db9e1d07d3318bb21e9e9c474f4c1e9c8df' },
   vhs: { label: 'Video Helper Suite', folder: 'ComfyUI-VideoHelperSuite', repo: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git', ref: '4ee72c065db22c9d96c2427954dc69e7b908444b' },
-  ltxvideo: { label: 'LTXVideo', folder: 'ComfyUI-LTXVideo', repo: 'https://github.com/Lightricks/ComfyUI-LTXVideo.git', ref: 'aceeae9635f6d493f2893ba3c411a1c36031788a' },
+  ltxvideo: { label: 'LTXVideo', folder: 'ComfyUI-LTXVideo', repo: 'https://github.com/Lightricks/ComfyUI-LTXVideo.git', ref: 'aceeae9635f6d493f2893ba3c411a1c36031788a', compatibilityPatch: 'kornia-pad' },
   rife: { label: 'Frame Interpolation', folder: 'ComfyUI-Frame-Interpolation', repo: 'https://github.com/Fannovel16/ComfyUI-Frame-Interpolation.git', ref: '26545cc2dd95bc3d27f056016300673bdeee78f5' },
+  eros: { label: '10S Comfy Nodes', folder: '10S-Comfy-nodes', repo: 'https://github.com/TenStrip/10S-Comfy-nodes.git', ref: '257400c45394efb2fa53a0a8fe3b3e8ac7392548' },
   bfs: { label: 'BFS Nodes', folder: 'ComfyUI-BFSNodes', repo: 'https://github.com/alisson-anjos/ComfyUI-BFSNodes.git', ref: '7112d6e640941e5f9c6f0402efd592f8bf340a06' },
   scailInfinity: { label: 'SCAIL 2 Infinity', folder: 'comfyui-scail2-infinity', repo: 'https://github.com/collbroGTR/comfyui-scail2-infinity.git', ref: '08dcf0d56979fc2238ce8c7716dad6cb7e9c9a89' },
   regional: {
     label: 'Krea 2 Regional MultiLoRA',
-    folder: 'ComfyUI-Krea2Regional-MultiLoRA',
-    repo: 'https://github.com/FedorShcherbakov/ComfyUI-Krea2Regional-MultiLoRA.git',
-    automaticInstall: false,
-    unavailableReason: 'its reviewed upstream repository is not currently available as a public checkout',
+    folder: 'Krea2-Multi-Character-Lora-Node-w-bounding-box-By-Fedor',
+    compatibleFolders: ['ComfyUI-Krea2Regional-MultiLoRA'],
+    repo: 'https://github.com/CliffNodes/Krea2-Multi-Character-Lora-Node-w-bounding-box-By-Fedor.git',
+    ref: '3c3541029b5de88f0e6eebce7ece7cb7d4f65b0f',
+    allowCompatibleMirror: true,
+    nodeSignatures: [{ file: 'krea2_regional_multilora_v3.py', values: ['class Krea2RegionalMultiLoRAV3', 'NODE_CLASS_MAPPINGS'] }],
   },
   krea2Control: { label: 'Krea 2 ControlNet', folder: 'comfyui-krea2-controlnet', repo: 'https://github.com/facok/comfyui-krea2-controlnet.git', ref: '79ebfd3bd80d2180b334dd7ce57f3c9ddaa0848f' },
   depthAnything3: { label: 'Depth Anything V3', folder: 'ComfyUI-DepthAnythingV3', repo: 'https://github.com/PozzettiAndrea/ComfyUI-DepthAnythingV3.git', ref: '6b08cf418dff47430a72e07d0eec8fdb07d464b1' },
@@ -99,14 +103,14 @@ const MODEL_ASSETS = Object.freeze({
     ['qwenEditAnglesLora', 'loras', hf('art1455/Qwen2511', 'qwen_image_edit_2511_multiple-angles-lora.safetensors')],
   ],
   upscale: [
-    ['seedvr2Dit', 'SEEDVR2', hf('Comfy-Org/SeedVR2', 'dit/seedvr2_ema_7b_fp8_e4m3fn_mixed_block35_fp16.safetensors')],
-    ['seedvr2Vae', 'SEEDVR2', hf('Comfy-Org/SeedVR2', 'vae/ema_vae_fp16.safetensors')],
+    ['seedvr2Dit', 'SEEDVR2', hf('AInVFX/SeedVR2_comfyUI', 'seedvr2_ema_7b_fp8_e4m3fn_mixed_block35_fp16.safetensors')],
+    ['seedvr2Vae', 'SEEDVR2', hf('numz/SeedVR2_comfyUI', 'ema_vae_fp16.safetensors')],
   ],
   ltx: [
     ['ltxCkpt', 'checkpoints', hf('Lightricks/LTX-2.3-fp8', 'ltx-2.3-22b-dev-fp8.safetensors')],
     ['ltxDistilledLora', 'loras', hf('Lightricks/LTX-2.3', 'ltx-2.3-22b-distilled-lora-384.safetensors')],
     ['ltxTextEncoder', 'text_encoders', hf('Lightricks/LTX-2.3', 'gemma_3_12B_it_fp4_mixed.safetensors')],
-    ['ltxGemmaLora', 'loras', hf('Lightricks/LTX-2.3', 'gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors')],
+    ['ltxGemmaLora', 'loras', hf('Comfy-Org/ltx-2', 'split_files/loras/gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors'), undefined, [hf('Lightricks/LTX-2.3', 'gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors')]],
     ['ltxUpscaler', 'latent_upscale_models', hf('Lightricks/LTX-2.3', 'ltx-2.3-spatial-upscaler-x2-1.1.safetensors')],
   ],
   ltxCamera: [
@@ -116,15 +120,15 @@ const MODEL_ASSETS = Object.freeze({
     ['ltxDirectorIcLora', 'loras', hf('Lightricks/LTX-2.3-22b-IC-LoRA-Ingredients', 'ltx-2.3-22b-ic-lora-ingredients-0.9.safetensors')],
   ],
   ltxEdit: [
-    ['ltxEditLora', 'loras', hf('Kijai/LTX-2.3-Edit-Anything', 'edit_anything_v1.1_r256.safetensors')],
+    ['ltxEditLora', 'loras', hf('Alissonerdx/EditAnything', 'edit_anything_v1.1_r256.safetensors')],
   ],
   faceid: [
     ['ltxFaceIdLora', 'loras', hf('Kijai/LTX-2.3-FaceID', 'Best_FaceID_v1.0_LoRA.safetensors')],
     ['ltxFaceIdDistilledLora', 'loras', hf('Lightricks/LTX-2.3', 'ltx-2.3-22b-distilled-1.1_lora-dynamic_fro09_avg_rank_111_bf16.safetensors')],
   ],
   wan: [
-    ['wanHighUnet', 'diffusion_models', hf('Wan-AI/Wan2.2-I2V-A14B', 'diffusion_models/wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors')],
-    ['wanLowUnet', 'diffusion_models', hf('Wan-AI/Wan2.2-I2V-A14B', 'diffusion_models/wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors')],
+    ['wanHighUnet', 'diffusion_models', hf('Comfy-Org/Wan_2.2_ComfyUI_Repackaged', 'split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors')],
+    ['wanLowUnet', 'diffusion_models', hf('Comfy-Org/Wan_2.2_ComfyUI_Repackaged', 'split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors')],
     ['wanClip', 'text_encoders', hf('Comfy-Org/Wan_2.1_ComfyUI_repackaged', 'split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors')],
     ['wanVae', 'vae', hf('Comfy-Org/Wan_2.1_ComfyUI_repackaged', 'split_files/vae/wan_2.1_vae.safetensors')],
     ['wanHighLora', 'loras', hf('lightx2v/Wan2.2-Lightning', 'wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors')],
@@ -132,7 +136,7 @@ const MODEL_ASSETS = Object.freeze({
   ],
   eros: [
     ['erosCkpt', 'checkpoints', hf('Tridae/ErosDeployment_ComfyUI', 'checkpoints/10Eros_v1.2_fp8mixed_learned.safetensors')],
-    ['erosTextEncoder', 'text_encoders', hf('Tridae/ErosDeployment_ComfyUI', 'text_encoders/gemma-3-12b-it-ablit-norms-biproj-fp8mixed.safetensors')],
+    ['erosTextEncoder', 'text_encoders', hf('Tridae/ErosDeployment_ComfyUI', 'text_encoders/gemma_3_12B_it_heretic_fp8_e4m3fn.safetensors')],
     ['erosDmdLora', 'loras', hf('Tridae/ErosDeployment_ComfyUI', 'loras/LTX2.3_DMD_reshaped_r256.safetensors')],
   ],
   scail: [
@@ -186,7 +190,7 @@ function dependencyModelPlan(modelGroups, settings = {}, options = {}) {
 
 const COMPONENTS = Object.freeze({
   smartmask: { label: 'Smart Mask Tools', nodes: ['sam3'] },
-  regional: { label: 'Regional Prompting (manual node required)', nodes: ['regional', 'kjnodes'], models: ['image'] },
+  regional: { label: 'Regional Prompting', nodes: ['regional', 'kjnodes'], models: ['image'] },
   krea2ref: { label: 'Krea 2 Edit', nodes: ['rebalance'], models: ['image'] },
   krea2outpaint: { label: 'Krea 2 Expand', nodes: ['krea2Edit', 'kjnodes'], models: ['image', 'krea2Outpaint'] },
   editoutpaint: { label: 'Klein / Qwen Expand', nodes: ['kjnodes'] },
@@ -198,7 +202,8 @@ const COMPONENTS = Object.freeze({
   videoedit: { label: 'LTX Edit', nodes: ['vhs'], models: ['ltxEdit'] },
   video4k: { label: 'RTX Video Super Resolution', nodes: [] },
   wan: { label: 'Wan 2.2 Video', nodes: ['vhs', 'gguf'], models: ['wan'] },
-  eros: { label: '10Eros DMD', nodes: ['kjnodes'], models: ['eros', 'ltx'] },
+  eros: { label: '10Eros DMD', nodes: ['eros', 'kjnodes'], models: ['eros', 'ltx'] },
+  rife: { label: 'RIFE Frame Interpolation', nodes: ['rife'], models: [] },
   scail: { label: 'SCAIL 2 Motion Transfer', nodes: ['sam3', 'vhs', 'gguf'], models: ['scail', 'wan'] },
   scailinfinity: { label: 'SCAIL 2 Infinity', nodes: ['scailInfinity'], models: ['scail'] },
   faceid: { label: 'LTX Face ID', nodes: ['bfs', 'kjnodes'], models: ['faceid', 'ltx'] },
@@ -236,16 +241,11 @@ function throwIfCancelled(signal) {
 }
 
 function normalizeModelName(value) {
-  return String(value || '').trim().replace(/\\/g, '/').replace(/^\/+/, '').toLowerCase();
+  return normalizeModelPath(value);
 }
 
 function modelIsRegistered(filename, availableModelNames) {
-  const expected = normalizeModelName(filename);
-  if (!expected || !availableModelNames) return false;
-  for (const value of availableModelNames) {
-    if (normalizeModelName(value) === expected) return true;
-  }
-  return false;
+  return !!resolveRegisteredModelName(filename, availableModelNames);
 }
 
 async function validateModelFile(file, expectedExtension = path.extname(file)) {
@@ -419,6 +419,58 @@ function looksLikeCustomNodeFolder(nodePath) {
   }
 }
 
+function nodePackHasSignatures(pack, nodePath) {
+  const signatures = Array.isArray(pack?.nodeSignatures) ? pack.nodeSignatures : [];
+  if (!signatures.length) return false;
+  try {
+    return signatures.every((signature) => {
+      const source = fs.readFileSync(path.join(nodePath, signature.file), 'utf8');
+      return (signature.values || []).every((value) => source.includes(value));
+    });
+  } catch {
+    return false;
+  }
+}
+
+async function patchLtxVideoKornia(nodePath) {
+  const file = path.join(nodePath, 'pyramid_blending.py');
+  let source;
+  try { source = await fsp.readFile(file, 'utf8'); } catch { return false; }
+  if (!source.includes('from kornia.geometry.transform.pyramid import (') || !/^[ \t]*pad,\r?$/m.test(source)) return false;
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  const patched = source
+    .replace(/^import torch\r?$/m, (line) => `${line}${newline}from torch.nn.functional import pad`)
+    .replace(/^[ \t]*pad,\r?\n/m, '');
+  if (patched === source) return false;
+  await fsp.writeFile(file, patched, 'utf8');
+  return true;
+}
+
+function uvCandidates(pythonPath) {
+  const pythonDir = pythonPath ? path.dirname(pythonPath) : '';
+  return [path.join(pythonDir, 'uv.exe'), path.join(pythonDir, 'uv')];
+}
+
+async function ensureUv(status, report, options = {}) {
+  const existsSync = options.existsSync || fs.existsSync;
+  const found = uvCandidates(status.pythonPath).find((candidate) => existsSync(candidate));
+  if (found) return found;
+  report('installing-uv', 'Installing uv into the ComfyUI Python environment for isolated custom-node setup');
+  try {
+    await (options.run || run)(status.pythonPath, [
+      '-m', 'pip', 'install', '--upgrade-strategy', 'only-if-needed', 'uv',
+    ], { cwd: status.basePath, signal: options.signal });
+  } catch (error) {
+    const wrapped = new Error(
+      `Custom-node setup needs uv beside the ComfyUI Python executable (${status.pythonPath}). `
+      + `Mix Studio could not install it automatically: ${String(error.message || error)}`
+    );
+    wrapped.code = 'dependency_uv_missing';
+    throw wrapped;
+  }
+  return uvCandidates(status.pythonPath)[0];
+}
+
 function unavailableNodePackError(pack, nodePath) {
   const error = new Error(
     `${pack.label} cannot be installed automatically because ${pack.unavailableReason || 'its reviewed source is unavailable'}. `
@@ -440,7 +492,11 @@ async function installNodePack(pack, status, report, options = {}) {
   const runCommand = options.run || run;
   const existsSync = options.existsSync || fs.existsSync;
   const gitExecutable = String(options.gitExecutable || process.env.MIX_STUDIO_GIT || 'git').trim() || 'git';
-  const nodePath = path.join(status.customNodesPath, pack.folder);
+  const preferredNodePath = path.join(status.customNodesPath, pack.folder);
+  const compatibleNodePaths = (pack.compatibleFolders || [])
+    .map((folder) => path.join(status.customNodesPath, folder));
+  const nodePath = [preferredNodePath, ...compatibleNodePaths]
+    .find((candidate) => existsSync(candidate)) || preferredNodePath;
   const gitDir = path.join(nodePath, '.git');
   throwIfCancelled(options.signal);
   assertNodePackSourceAvailable(pack, status);
@@ -454,8 +510,18 @@ async function installNodePack(pack, status, report, options = {}) {
     report('existing-node', `Using the existing ${pack.label} installation without changing its source`, { unmanaged: true });
   } else if (gitManaged) {
     const origin = await runCommand(gitExecutable, ['-C', nodePath, 'remote', 'get-url', 'origin'], { cwd: nodePath, signal: options.signal });
-    if (!sameRepo(origin, pack.repo)) throw new Error(`${pack.label} exists but points to a different repository.`);
-    if (pack.automaticInstall === false) {
+    const compatibleMirror = !sameRepo(origin, pack.repo)
+      && pack.allowCompatibleMirror === true
+      && nodePackHasSignatures(pack, nodePath);
+    if (!sameRepo(origin, pack.repo) && !compatibleMirror) {
+      throw new Error(`${pack.label} exists but points to a different repository and does not expose the required node classes.`);
+    }
+    if (compatibleMirror) {
+      report('existing-node', `Using the compatible ${pack.label} mirror already installed`, {
+        compatibleMirror: true,
+        origin: String(origin || '').trim(),
+      });
+    } else if (pack.automaticInstall === false) {
       report('existing-node', `Using the existing ${pack.label} installation; its reviewed source is unavailable`, {
         sourceUnavailable: true,
       });
@@ -480,6 +546,9 @@ async function installNodePack(pack, status, report, options = {}) {
       await runCommand(gitExecutable, ['-C', nodePath, 'checkout', '--detach', pack.ref], { cwd: nodePath, signal: options.signal });
     }
   }
+  if (pack.compatibilityPatch === 'kornia-pad' && await patchLtxVideoKornia(nodePath)) {
+    report('compatibility-patch', `Updated ${pack.label} for kornia 0.8.3 and newer`);
+  }
   const requirements = path.join(nodePath, 'requirements.txt');
   if (existsSync(requirements)) {
     const repair = !!options.repair;
@@ -503,8 +572,10 @@ async function installNodePack(pack, status, report, options = {}) {
 }
 
 async function downloadAsset(asset, modelsPath, settings, report, options = {}) {
-  const [settingKey, folder, url, defaultFilename] = asset;
-  const sourceName = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+  const [settingKey, folder, url, defaultFilename, fallbackUrls] = asset;
+  const sources = [...new Set([url, ...(Array.isArray(fallbackUrls) ? fallbackUrls : [])].filter(Boolean))];
+  const primarySourceName = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+  let sourceName = primarySourceName;
   const filename = cleanRelative(settings[settingKey] || defaultFilename || sourceName);
   const destination = path.join(modelsPath, folder, filename);
   throwIfCancelled(options.signal);
@@ -554,22 +625,52 @@ async function downloadAsset(asset, modelsPath, settings, report, options = {}) 
   const partial = `${destination}.mixbox.part`;
   await fsp.rm(partial, { force: true }).catch(() => {});
   report('downloading-model', `Downloading ${filename}`, { settingKey, filename, downloaded: 0, downloadTotal: 0 });
-  const headers = process.env.HF_TOKEN ? { Authorization: `Bearer ${process.env.HF_TOKEN}` } : {};
-  const response = await (options.fetch || fetch)(url, { headers, redirect: 'follow', signal: options.signal });
-  if (!response.ok || !response.body) {
-    const detail = await response.text().catch(() => '');
-    const accessUrl = huggingFaceAccessUrl(url);
-    const accessRequired = accessUrl && (response.status === 401 || response.status === 403);
+  const hfToken = String(options.hfToken || process.env.HF_TOKEN || '').trim();
+  let response = null;
+  let selectedUrl = url;
+  const failures = [];
+  for (let index = 0; index < sources.length; index += 1) {
+    selectedUrl = sources[index];
+    try {
+      const sourceHost = new URL(selectedUrl).hostname.toLowerCase();
+      const headers = hfToken && sourceHost === 'huggingface.co'
+        ? { Authorization: `Bearer ${hfToken}` }
+        : {};
+      response = await (options.fetch || fetch)(selectedUrl, { headers, redirect: 'follow', signal: options.signal });
+    } catch (error) {
+      if (options.signal?.aborted || error?.name === 'AbortError' || error?.code === 'ABORT_ERR') throw dependencyCancelledError();
+      failures.push({ url: selectedUrl, status: 0, detail: String(error.message || error) });
+      response = null;
+    }
+    if (response?.ok && response.body) break;
+    if (response) failures.push({
+      url: selectedUrl,
+      status: response.status,
+      detail: await response.text().catch(() => ''),
+    });
+    response = null;
+    if (index < sources.length - 1) {
+      report('download-fallback', `The primary source for ${filename} was unavailable; trying a reviewed mirror`, {
+        settingKey, filename, sourceIndex: index + 1,
+      });
+    }
+  }
+  if (!response || !response.ok || !response.body) {
+    const failure = failures[failures.length - 1] || { url: selectedUrl, status: 0, detail: '' };
+    const accessFailure = [...failures].reverse().find((entry) => entry.status === 401 || entry.status === 403);
+    const accessUrl = huggingFaceAccessUrl(accessFailure?.url || '');
+    const accessRequired = !!accessUrl;
     const error = new Error(accessRequired
-      ? `Hugging Face access is required for ${filename}. Open the model page, sign in and accept or request access, then retry with an HF_TOKEN from that account.`
-      : `Could not download ${filename} (${response.status}). ${detail.slice(0, 240) || 'Check the connection and source model access, then try again.'}`);
+      ? `Hugging Face access is required for ${filename}. Accept the model license, then paste a read token into Settings → General → Hugging Face token and retry.`
+      : `Could not download ${filename}${failure.status ? ` (${failure.status})` : ''}. ${failure.detail.slice(0, 240) || 'All reviewed sources were unavailable; check the connection and try again.'}`);
     error.code = accessRequired ? 'dependency_model_access_required' : 'dependency_download_failed';
-    error.statusCode = response.status;
+    error.statusCode = accessFailure?.status || failure.status || null;
     error.settingKey = settingKey;
     error.failedModel = filename;
     if (accessRequired) error.accessUrl = accessUrl;
     throw error;
   }
+  sourceName = decodeURIComponent(new URL(selectedUrl).pathname.split('/').pop() || primarySourceName);
   const total = Number(response.headers.get('content-length') || 0);
   try {
     await ensureDownloadDiskSpace(path.dirname(destination), total, options);
@@ -642,6 +743,9 @@ async function installComponents({ runtime, settings, components, report = () =>
     ? await snapshotPythonEnvironment(status, runtime, (phase, message, detail) => report(phase, message, Object.assign({ completed, total }, detail || {})), options)
     : '';
   const runtimeConstraintFile = await createRuntimeConstraintFile(environmentSnapshot);
+  if (nodeIds.length) {
+    await ensureUv(status, (phase, message, detail) => report(phase, message, Object.assign({ completed, total }, detail || {})), options);
+  }
   for (const id of nodeIds) {
     throwIfCancelled(options.signal);
     const pack = NODE_PACKS[id];
@@ -694,6 +798,9 @@ module.exports = {
   ensureDownloadDiskSpace,
   filterProtectedRuntimeRequirements,
   huggingFaceAccessUrl,
+  ensureUv,
+  nodePackHasSignatures,
+  patchLtxVideoKornia,
   protectedRuntimeConstraints,
   installNodePack,
   installComponents,

--- a/lib/features.js
+++ b/lib/features.js
@@ -25,6 +25,7 @@ const DEFAULT_FEATURES = Object.freeze({
   'video.ltx': true,
   'video.ltxEdit': true,
   'video.eros': true,
+  'video.rife': true,
   'video.wan': true,
   'video.scail': true,
 });

--- a/lib/model-loader.js
+++ b/lib/model-loader.js
@@ -1,5 +1,51 @@
 'use strict';
 
+const MODEL_FILE_RE = /\.(?:safetensors|ckpt|pt|pth|bin|gguf|onnx)$/i;
+
+function normalizeModelPath(value) {
+  return String(value || '').trim().replace(/\\/g, '/').replace(/^\/+/, '').toLowerCase();
+}
+
+function modelBasename(value) {
+  const normalized = normalizeModelPath(value);
+  return normalized.slice(normalized.lastIndexOf('/') + 1);
+}
+
+function modelChoice(value) {
+  return typeof value === 'string' && MODEL_FILE_RE.test(value.trim());
+}
+
+function registeredModelNames(info) {
+  const names = new Set();
+  for (const cls of Object.values(info || {})) {
+    const inputs = cls && typeof cls === 'object' ? cls.input || {} : {};
+    for (const group of [inputs.required, inputs.optional]) {
+      for (const spec of Object.values(group || {})) {
+        if (!Array.isArray(spec)) continue;
+        const choices = Array.isArray(spec[0])
+          ? spec[0]
+          : (spec[0] === 'COMBO' && Array.isArray(spec[1]?.options) ? spec[1].options : []);
+        for (const choice of choices) if (modelChoice(choice)) names.add(choice.trim());
+      }
+    }
+  }
+  return [...names].sort((left, right) => left.localeCompare(right));
+}
+
+/** Resolve a configured bare filename to the exact path ComfyUI registered.
+ * Basename fallback is only safe when it has one match; duplicate filenames
+ * in separate model roots remain a user choice. */
+function resolveRegisteredModelName(value, availableNames) {
+  const expected = normalizeModelPath(value);
+  if (!expected || !availableNames) return '';
+  const choices = [...availableNames].filter(modelChoice);
+  const exact = choices.find((choice) => normalizeModelPath(choice) === expected);
+  if (exact) return exact;
+  const basename = modelBasename(expected);
+  const matches = choices.filter((choice) => modelBasename(choice) === basename);
+  return matches.length === 1 ? matches[0] : '';
+}
+
 function isGgufModel(name) {
   return /\.gguf$/i.test(String(name || '').trim());
 }
@@ -18,4 +64,14 @@ function diffusionModelInput(name) {
     : { className: 'UNETLoader', field: 'unet_name' };
 }
 
-module.exports = { diffusionModelInput, diffusionModelLoader, isGgufModel };
+module.exports = {
+  MODEL_FILE_RE,
+  diffusionModelInput,
+  diffusionModelLoader,
+  isGgufModel,
+  modelBasename,
+  modelChoice,
+  normalizeModelPath,
+  registeredModelNames,
+  resolveRegisteredModelName,
+};

--- a/lib/regional-workflows.js
+++ b/lib/regional-workflows.js
@@ -213,6 +213,8 @@ function addRegionalPrompting(graph, params, model, clip) {
       aesthetics: '',
       lighting: '',
       medium: '',
+      import_mode: 'when empty',
+      output_format: 'compact',
       style_palette_data: '[]',
       elements_data: regionalPromptBuilderJson(regions),
       bg_brightness: 25,
@@ -334,6 +336,9 @@ function buildKrea2InpaintGraph(params) {
         clip,
         image1: ['source', 0],
         image1_tokens: 'high',
+        refocus_strength: 0.8,
+        guidance_strength: 0.5,
+        enable_split: true,
       },
     };
   } else {

--- a/lib/setup-guide.js
+++ b/lib/setup-guide.js
@@ -24,6 +24,7 @@ const FEATURE_COMPONENTS = Object.freeze({
   'video.eros': ['eros'],
   'video.wan': ['wan'],
   'video.scail': ['scail', 'scailinfinity'],
+  'video.rife': ['rife'],
 });
 
 const FIT_PRIORITY = Object.freeze({ unknown: 0, difficult: 1, limited: 2, recommended: 3 });

--- a/public/app.js
+++ b/public/app.js
@@ -24024,7 +24024,7 @@ function mediaPreferenceControlValue(id) {
 }
 
 const SETTINGS_SERVER_CONTROL_IDS = new Set([
-  'setComfy', 'galleryPasswordInput', 'setVramProfile', 'setKrea2ModelVariant',
+  'setComfy', 'setHfToken', 'galleryPasswordInput', 'setVramProfile', 'setKrea2ModelVariant',
   'setUnet', 'setKrea2RawUnet', 'setKrea2TurboLora', 'setKrea2DepthLora',
   'setKrea2OutpaintLora', 'setDepthAnythingV3Model', 'setClip', 'setVae',
   'setKlein4Unet', 'setKlein4Clip', 'setKlein4ConsistencyLora', 'setKlein4ConsistencyTrigger',
@@ -24056,6 +24056,7 @@ let settingsAppRestartRunning = false;
 function settingsPayload() {
   return {
     comfyUrl: $('#setComfy').value,
+    hfToken: $('#setHfToken').value,
     galleryPassword: $('#galleryPasswordInput').value.trim() || '1234',
     vramProfile: $('#setVramProfile').value,
     krea2ModelVariant: $('#setKrea2ModelVariant').value,
@@ -26931,6 +26932,10 @@ $('#settingsBtn').addEventListener('click', async () => {
   try {
     const s = await api('/api/settings');
     $('#setComfy').value = s.comfyUrl;
+    $('#setHfToken').value = '';
+    $('#setHfToken').placeholder = s.hfTokenConfigured
+      ? 'Saved · paste a new token to replace it'
+      : 'Paste an hf_ read token';
     $('#galleryPasswordInput').value = s.galleryPassword || '1234';
     $('#setVramProfile').value = s.vramProfile || 'auto';
     $('#setKrea2ModelVariant').value = s.krea2ModelVariant || (/int8.*convrot|convrot.*int8/i.test(s.unet || '') ? 'int8-convrot' : 'fp8');
@@ -28624,7 +28629,7 @@ function renderHealth() {
     return;
   }
   const rows = [`<span class="ok">● Connected</span> — ${state.metaLoras.length} LoRAs found`];
-  const labels = { core: 'Core nodes', enhance: 'Prompt enhance (TextGenerate)', klein: 'Edit (Flux 2 Klein) nodes', qwenedit: 'Edit (Qwen Image Edit) nodes', regional: 'Krea2 regional prompting nodes', krea2inpaint: 'Krea2 Fill nodes', krea2ref: 'Krea 2 Edit (Rebalance) nodes', krea2outpaint: 'Krea 2 Expand nodes', editoutpaint: 'Klein / Qwen Expand nodes', smartmask: 'Smart Mask (SAM3) nodes', upscale: 'SeedVR2 nodes', ultimateupscale: 'Ultimate SD Upscale nodes', video: 'LTX 2.3 video nodes', ltxdirector: 'LTX Director nodes', videoedit: 'LTX Edit guide-video nodes', video4k: 'RTX 4K pass (optional)', wan: 'Wan 2.2 nodes', eros: '10Eros DMD nodes', scail: 'SCAIL 2 motion transfer nodes', scailinfinity: 'SCAIL 2 Infinity node', faceid: 'LTX Face ID (BFS) nodes' };
+  const labels = { core: 'Core nodes', enhance: 'Prompt enhance (TextGenerate)', klein: 'Edit (Flux 2 Klein) nodes', qwenedit: 'Edit (Qwen Image Edit) nodes', regional: 'Krea2 regional prompting nodes', krea2inpaint: 'Krea2 Fill nodes', krea2ref: 'Krea 2 Edit (Rebalance) nodes', krea2outpaint: 'Krea 2 Expand nodes', editoutpaint: 'Klein / Qwen Expand nodes', smartmask: 'Smart Mask (SAM3) nodes', upscale: 'SeedVR2 nodes', ultimateupscale: 'Ultimate SD Upscale nodes', video: 'LTX 2.3 video nodes', ltxdirector: 'LTX Director nodes', videoedit: 'LTX Edit guide-video nodes', video4k: 'RTX 4K pass (optional)', rife: 'RIFE frame interpolation nodes', wan: 'Wan 2.2 nodes', eros: '10Eros DMD nodes', scail: 'SCAIL 2 motion transfer nodes', scailinfinity: 'SCAIL 2 Infinity node', faceid: 'LTX Face ID (BFS) nodes' };
   for (const [group, missing] of Object.entries(lastMeta.missing || {})) {
     if (group === 'smartmask') continue; // The actionable installer card above owns this status.
     const label = labels[group] || group.replace(/([a-z])([A-Z])/g, '$1 $2');

--- a/public/index.html
+++ b/public/index.html
@@ -2111,7 +2111,7 @@
         </div>
         <div class="dependency-access" id="setupDependencyAccess" hidden>
           <span class="dependency-access-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M7 10V7a5 5 0 0 1 10 0v3M6 10h12v10H6V10Zm6 4v2"/></svg></span>
-          <span class="dependency-access-copy"><strong>Hugging Face access required</strong><small>Sign in and accept or request access. This installer also needs an HF_TOKEN from that account.</small></span>
+          <span class="dependency-access-copy"><strong>Hugging Face access required</strong><small>Accept the model license, then add a read token in Settings → General → Hugging Face token.</small></span>
           <a class="dependency-access-link" id="setupDependencyAccessLink" target="_blank" rel="noopener noreferrer"><span>Open model page</span><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5h5v5M13 11l6-6M19 13v5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h5"/></svg></a>
         </div>
         <div class="setup-operation-actions">
@@ -2306,6 +2306,11 @@
             <svg class="generation-setup-entry-arrow" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 6 6 6-6 6"/></svg>
           </button>
           <div class="field"><label>ComfyUI URL</label><input id="setComfy" type="text" /></div>
+          <div class="field">
+            <label>Hugging Face token</label>
+            <input id="setHfToken" type="password" autocomplete="new-password" placeholder="Paste an hf_ read token" />
+            <small>Some gated downloads require both accepting the model license on Hugging Face and a read token here. The saved token is never returned to the browser.</small>
+          </div>
           <div class="field"><label>Gallery password</label><input id="galleryPasswordInput" type="password" value="1234" autocomplete="new-password" /></div>
           <div class="settings-note">Model names must match the files installed in your ComfyUI folders.</div>
           <div class="dependency-card" id="sam3DependencyCard">
@@ -2332,7 +2337,7 @@
             <div class="dependency-progress" id="dependencyProgress" hidden><span id="dependencyProgressFill"></span></div>
             <div class="dependency-access" id="dependencyAccess" hidden>
               <span class="dependency-access-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M7 10V7a5 5 0 0 1 10 0v3M6 10h12v10H6V10Zm6 4v2"/></svg></span>
-              <span class="dependency-access-copy"><strong>Hugging Face access required</strong><small>Sign in and accept or request access. This installer also needs an HF_TOKEN from that account.</small></span>
+              <span class="dependency-access-copy"><strong>Hugging Face access required</strong><small>Accept the model license, then paste a read token in Settings → General → Hugging Face token.</small></span>
               <a class="dependency-access-link" id="dependencyAccessLink" target="_blank" rel="noopener noreferrer"><span>Open model page</span><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 5h5v5M13 11l6-6M19 13v5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h5"/></svg></a>
             </div>
             <div class="dependency-selection-head" id="dependencySelectionHead" hidden>

--- a/server.js
+++ b/server.js
@@ -195,7 +195,14 @@ const {
   normalizeKrea2Variant,
   recommendedKrea2Variant,
 } = require('./lib/krea2-model');
-const { diffusionModelInput, diffusionModelLoader } = require('./lib/model-loader');
+const {
+  diffusionModelInput,
+  diffusionModelLoader,
+  modelChoice,
+  normalizeModelPath,
+  registeredModelNames,
+  resolveRegisteredModelName,
+} = require('./lib/model-loader');
 const {
   applyLowVramImageLimits,
   normalizeVramProfile,
@@ -289,6 +296,7 @@ User's Input:`;
 
 const DEFAULT_SETTINGS = {
   comfyUrl: RUNTIME.comfy.url || 'http://127.0.0.1:8188',
+  hfToken: '',
   unet: 'krea2_turbo_fp8_scaled.safetensors',
   krea2RawUnet: 'krea2_raw_fp8_scaled.safetensors',
   krea2ModelVariant: 'fp8',
@@ -333,7 +341,7 @@ const DEFAULT_SETTINGS = {
   wanHighLora: 'wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors',
   wanLowLora: 'wan2.2_t2v_lightx2v_4steps_lora_v1.1_low_noise.safetensors',
   erosCkpt: '10Eros_v1.2_fp8mixed_learned.safetensors',
-  erosTextEncoder: 'gemma-3-12b-it-ablit-norms-biproj-fp8mixed.safetensors',
+  erosTextEncoder: 'gemma_3_12B_it_heretic_fp8_e4m3fn.safetensors',
   erosDmdLora: 'LTX2.3_DMD_reshaped_r256.safetensors',
   erosSigmasFirst: '',
   erosSigmasUpscale: '',
@@ -387,7 +395,12 @@ function settingsRequireAppRestart() {
 }
 
 function settingsResponse() {
-  return Object.assign({}, settings, { appRestartRequired: settingsRequireAppRestart() });
+  const response = Object.assign({}, settings, {
+    hfTokenConfigured: !!String(settings.hfToken || process.env.HF_TOKEN || '').trim(),
+    appRestartRequired: settingsRequireAppRestart(),
+  });
+  delete response.hfToken;
+  return response;
 }
 
 function seedVr2ModelDirs() {
@@ -921,23 +934,6 @@ function browseGenerationFolder(kind) {
   });
 }
 
-function registeredModelNames(info) {
-  const names = new Set();
-  for (const cls of Object.values(info || {})) {
-    const inputs = cls?.input || {};
-    for (const group of [inputs.required, inputs.optional]) {
-      for (const spec of Object.values(group || {})) {
-        if (!Array.isArray(spec)) continue;
-        const choices = Array.isArray(spec[0])
-          ? spec[0]
-          : (spec[0] === 'COMBO' && Array.isArray(spec[1]?.options) ? spec[1].options : []);
-        for (const choice of choices) if (typeof choice === 'string') names.add(choice);
-      }
-    }
-  }
-  return names;
-}
-
 async function assertDesktopIsIdle() {
   const busy = (message) => {
     const error = new Error(message);
@@ -1092,7 +1088,19 @@ async function queueHealth(running, pending) {
 
 async function comfyFetch(p, opts) {
   const url = settings.comfyUrl.replace(/\/$/, '') + p;
-  const res = await fetch(url, opts);
+  let res;
+  try {
+    res = await fetch(url, opts);
+  } catch (error) {
+    const detail = String(error?.cause?.message || error?.message || error || 'connection failed');
+    const wrapped = new Error(
+      `Could not reach ComfyUI for ${String(opts?.method || 'GET').toUpperCase()} ${p}: ${detail}. `
+      + `Check that ComfyUI is running at ${settings.comfyUrl}.`
+    );
+    wrapped.code = 'comfy_connection_failed';
+    wrapped.cause = error;
+    throw wrapped;
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`ComfyUI ${p} -> ${res.status} ${text.slice(0, 400)}`);
@@ -1138,7 +1146,22 @@ async function getObjectInfo(force, fetchOptions) {
   const res = await comfyFetch('/object_info', fetchOptions);
   objectInfoCache = await res.json();
   objectInfoAt = Date.now();
+  adoptRegisteredModelPaths(objectInfoCache);
   return objectInfoCache;
+}
+
+function adoptRegisteredModelPaths(info) {
+  const available = registeredModelNames(info);
+  let changed = false;
+  for (const key of Object.keys(DEFAULT_SETTINGS)) {
+    if (!modelChoice(settings[key])) continue;
+    const resolved = resolveRegisteredModelName(settings[key], available);
+    if (!resolved || normalizeModelPath(resolved) === normalizeModelPath(settings[key])) continue;
+    settings[key] = resolved;
+    changed = true;
+  }
+  if (changed) saveJsonSync(SETTINGS_FILE, settings);
+  return changed;
 }
 
 function comboList(info, cls, field) {
@@ -1147,7 +1170,8 @@ function comboList(info, cls, field) {
 
 function modelStatus(info, cls, field, name, fallbackList) {
   const list = fallbackList || comboList(info, cls, field);
-  return { name, ok: !name || list.includes(name) };
+  const resolved = resolveRegisteredModelName(name, list);
+  return { name: resolved || name, ok: !name || !!resolved };
 }
 
 function diffusionModelStatus(info, name) {
@@ -1157,7 +1181,8 @@ function diffusionModelStatus(info, name) {
 
 function modelStatusAny(info, name, choices, fallbackList) {
   const list = fallbackList || choices.flatMap(([cls, field]) => comboList(info, cls, field));
-  return { name, ok: !name || list.includes(name) };
+  const resolved = resolveRegisteredModelName(name, list);
+  return { name: resolved || name, ok: !name || !!resolved };
 }
 
 function scailInfinityStatus(info) {
@@ -1168,7 +1193,7 @@ function scailInfinityStatus(info) {
     node: { name: 'WanSCAILInfinity', ok: !!info.WanSCAILInfinity },
     pusa: {
       name: settings.scailPusaLora,
-      ok: !!settings.scailPusaLora && loraList.includes(settings.scailPusaLora),
+      ok: !!settings.scailPusaLora && !!resolveRegisteredModelName(settings.scailPusaLora, loraList),
     },
   };
 }
@@ -1301,6 +1326,7 @@ function missingDependencyComponentIds(missing, models) {
     ltxdirector: ['ltxdirector'],
     videoedit: ['videoedit'],
     video4k: ['video4k'],
+    rife: ['rife'],
     wan: ['wan'],
     eros: ['eros'],
     scail: ['scail'],
@@ -1475,11 +1501,21 @@ async function uploadToComfy(buffer, filename) {
   );
   const mid = Buffer.from(`\r\n--${boundary}\r\nContent-Disposition: form-data; name="overwrite"\r\n\r\ntrue\r\n--${boundary}--\r\n`);
   const body = Buffer.concat([head, buffer, mid]);
-  const res = await comfyFetch('/upload/image', {
-    method: 'POST',
-    headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
-    body,
-  });
+  let res;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      res = await comfyFetch('/upload/image', {
+        method: 'POST',
+        headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+        body,
+      });
+      break;
+    } catch (error) {
+      if (error?.code !== 'comfy_connection_failed' || attempt > 0) throw error;
+      resetComfyTransport();
+      await pause(750);
+    }
+  }
   const json = await res.json();
   return (json.subfolder ? json.subfolder + '/' : '') + json.name;
 }
@@ -1502,18 +1538,29 @@ async function uploadCameraMotionGuides(value) {
 }
 
 async function uploadFileToComfy(file, filename) {
-  const upload = await multipartFileUpload(file, filename);
-  const res = await comfyFetch('/upload/image', {
-    method: 'POST',
-    headers: {
-      'Content-Type': `multipart/form-data; boundary=${upload.boundary}`,
-      'Content-Length': String(upload.contentLength),
-    },
-    body: upload.body,
-    duplex: 'half',
-  });
-  const result = await res.json();
-  return (result.subfolder ? result.subfolder + '/' : '') + result.name;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const upload = await multipartFileUpload(file, filename);
+    try {
+      const res = await comfyFetch('/upload/image', {
+        method: 'POST',
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${upload.boundary}`,
+          'Content-Length': String(upload.contentLength),
+        },
+        body: upload.body,
+        duplex: 'half',
+      });
+      const result = await res.json();
+      return (result.subfolder ? result.subfolder + '/' : '') + result.name;
+    } catch (error) {
+      if (error?.code !== 'comfy_connection_failed' || attempt > 0) {
+        throw new Error(`Could not upload ${filename} to ComfyUI: ${String(error.message || error)}`, { cause: error });
+      }
+      resetComfyTransport();
+      await pause(750);
+    }
+  }
+  throw new Error(`Could not upload ${filename} to ComfyUI.`);
 }
 
 async function queuePrompt(graph, options = {}) {
@@ -1541,6 +1588,7 @@ let ws = null;
 let wsTimer = null;
 let lastPreviewAt = 0;
 let activeWsPromptId = '';
+let lastWsMessageAt = 0;
 
 function resetComfyTransport() {
   clearTimeout(wsTimer);
@@ -1556,6 +1604,7 @@ function resetComfyTransport() {
   }
   ws = null;
   activeWsPromptId = '';
+  lastWsMessageAt = 0;
   objectInfoCache = null;
   objectInfoAt = 0;
   comfyCompatibilitySnapshot = null;
@@ -1569,11 +1618,13 @@ function ensureWs() {
   try { ws = new WebSocket(url); } catch { return scheduleWsRetry(); }
   ws.binaryType = 'arraybuffer';
   ws.onopen = () => {
+    lastWsMessageAt = Date.now();
     // ComfyUI 0.27 sends sampler previews through PREVIEW_IMAGE_WITH_METADATA
     // only after this first-message capability negotiation.
     try { ws.send(JSON.stringify({ type: 'feature_flags', data: { supports_preview_metadata: true } })); } catch { /* noop */ }
   };
   ws.onmessage = async (ev) => {
+    lastWsMessageAt = Date.now();
     if (typeof ev.data === 'string') {
       let msg; try { msg = JSON.parse(ev.data); } catch { return; }
       handleWsMessage(msg);
@@ -2297,7 +2348,15 @@ async function completeJob(pid) {
 /* Polling fallback: no native WebSocket (Node < 22) OR the WS connection is down. */
 setInterval(async () => {
   if (!jobs.size) return;
-  if (typeof WebSocket !== 'undefined' && ws && ws.readyState === 1) return;
+  const socketOpen = typeof WebSocket !== 'undefined' && ws && ws.readyState === 1;
+  const socketStale = socketOpen && Date.now() - lastWsMessageAt > 15_000;
+  const needsTextReconciliation = [...jobs.values()]
+    .some((job) => ['enhance', 'motionPrompt', 'smartMask'].includes(job.kind));
+  if (socketOpen && !socketStale && !needsTextReconciliation) return;
+  if (socketStale) {
+    resetComfyTransport();
+    ensureWs();
+  }
   for (const pid of [...jobs.keys()]) {
     try {
       const hist = (await (await comfyFetch(`/history/${pid}`)).json())[pid];
@@ -2848,7 +2907,13 @@ async function buildEditKrea2Ref(p, refNames) {
     }
   } catch { /* fall back to the selected output size */ }
 
-  const rebalanceInputs = { text: p.prompt, clip: ['clip', 0] };
+  const rebalanceInputs = {
+    text: p.prompt,
+    clip: ['clip', 0],
+    refocus_strength: 0.8,
+    guidance_strength: 0.5,
+    enable_split: true,
+  };
   refNames.slice(0, 4).forEach((name, i) => {
     const k = i + 1;
     graph[`ref${k}`] = { class_type: 'LoadImage', inputs: { image: name } };
@@ -4776,6 +4841,7 @@ const REQUIRED_CLASSES = {
     'VHS_LoadVideo', 'ImageBatch'],
   videoedit: ['VHS_LoadVideo', 'LTXVAddGuide'],
   video4k: ['RTXVideoSuperResolution'],
+  rife: ['RIFE VFI'],
   wan: ['UNETLoader', 'CLIPLoader', 'VAELoader', 'LoraLoaderModelOnly', 'ModelSamplingSD3',
     'WanImageToVideo', 'KSamplerAdvanced', 'VAEDecode', 'CreateVideo', 'SaveVideo'],
   eros: ['CheckpointLoaderSimple', 'LTXVAudioVAELoader', 'LTXAVTextEncoderLoader', 'ImageResizeKJv2',
@@ -5336,6 +5402,7 @@ async function handleApi(req, res, url) {
       settings.krea2ModelVariant = body.krea2ModelVariant;
     }
     if (typeof body.smartFilenames === 'boolean') settings.smartFilenames = body.smartFilenames;
+    if (body.clearHfToken === true) settings.hfToken = '';
     if (body.features && typeof body.features === 'object') settings.features = normalizeFeatures(body.features);
     settings = normalizeSettings(settings);
     saveJsonSync(SETTINGS_FILE, settings);
@@ -5702,7 +5769,13 @@ async function handleApi(req, res, url) {
           runtime: RUNTIME,
           settings,
           components,
-          options: { repair, signal: installController.signal, availableModelNames, modelVariants },
+          options: {
+            repair,
+            signal: installController.signal,
+            availableModelNames,
+            modelVariants,
+            hfToken: settings.hfToken,
+          },
           report: (phase, message, detail) => {
             if (!installController.signal.aborted) updateDependencyInstallState(Object.assign({ state: 'running', phase, message }, detail || {}));
           },
@@ -5742,7 +5815,7 @@ async function handleApi(req, res, url) {
       try {
         const result = await installComponents({
           runtime: RUNTIME, settings, components: ['smartmask'],
-          options: { signal: installController.signal },
+          options: { signal: installController.signal, hfToken: settings.hfToken },
           report: (phase, message, detail) => {
             if (!installController.signal.aborted) updateDependencyInstallState(Object.assign({ state: 'running', phase, message }, detail || {}));
           },

--- a/test/dependency-manager.test.js
+++ b/test/dependency-manager.test.js
@@ -20,12 +20,14 @@ const {
   dependencyModelPlan,
   downloadAsset,
   ensureDownloadDiskSpace,
+  ensureUv,
   filterProtectedRuntimeRequirements,
   huggingFaceAccessUrl,
   installComponents,
   installNodePack,
   looksLikeCustomNodeFolder,
   modelIsRegistered,
+  patchLtxVideoKornia,
   protectedRuntimeConstraints,
   requirementsArgs,
   sameRepo,
@@ -41,17 +43,20 @@ function safetensorsFixture() {
 }
 
 test('dependency catalog covers every enabled image and video family', () => {
-  for (const component of ['image', 'krea2raw', 'krea2depth', 'krea2style', 'krea2outpaint', 'editoutpaint', 'klein4', 'klein9', 'qwen', 'upscale', 'video', 'ltxcamera', 'ltxdirector', 'videoedit', 'faceid', 'wan', 'eros', 'scail', 'scailinfinity', 'smartmask', 'regional']) {
+  for (const component of ['image', 'krea2raw', 'krea2depth', 'krea2style', 'krea2outpaint', 'editoutpaint', 'klein4', 'klein9', 'qwen', 'upscale', 'video', 'ltxcamera', 'ltxdirector', 'videoedit', 'faceid', 'wan', 'eros', 'rife', 'scail', 'scailinfinity', 'smartmask', 'regional']) {
     assert.ok(COMPONENTS[component], `${component} is installable`);
   }
   for (const group of ['image', 'krea2Raw', 'krea2Depth', 'krea2Outpaint', 'klein4', 'klein9', 'qwen', 'upscale', 'ltx', 'ltxCamera', 'ltxDirector', 'ltxEdit', 'faceid', 'wan', 'eros', 'scail']) {
     assert.ok(MODEL_ASSETS[group]?.length, `${group} has model downloads`);
   }
   assert.ok(Object.values(NODE_PACKS).every((pack) => pack.repo.startsWith('https://github.com/')));
-  assert.ok(Object.entries(NODE_PACKS).filter(([id]) => id !== 'regional')
-    .every(([, pack]) => /^[a-f0-9]{40}$/.test(pack.ref)), 'public custom nodes use immutable commits');
-  assert.equal(NODE_PACKS.regional.automaticInstall, false);
-  assert.match(COMPONENTS.regional.label, /manual node required/i);
+  assert.ok(Object.values(NODE_PACKS)
+    .every((pack) => /^[a-f0-9]{40}$/.test(pack.ref)), 'public custom nodes use immutable commits');
+  assert.match(NODE_PACKS.regional.repo, /CliffNodes\/Krea2-Multi-Character-Lora-Node/);
+  assert.equal(NODE_PACKS.regional.allowCompatibleMirror, true);
+  assert.match(NODE_PACKS.eros.repo, /TenStrip\/10S-Comfy-nodes/);
+  assert.deepEqual(COMPONENTS.eros.nodes, ['eros', 'kjnodes']);
+  assert.deepEqual(COMPONENTS.rife.nodes, ['rife']);
   assert.ok(availableComponents().includes('smartmask'));
   assert.equal(COMPONENTS.krea2raw.optional, true);
   assert.deepEqual(COMPONENTS.krea2raw.models, ['krea2Raw']);
@@ -69,6 +74,13 @@ test('dependency catalog covers every enabled image and video family', () => {
   assert.equal(NODE_PACKS.ltxvideo.folder, 'ComfyUI-LTXVideo');
   assert.match(NODE_PACKS.ltxvideo.repo, /Lightricks\/ComfyUI-LTXVideo/);
   assert.match(MODEL_ASSETS.ltxCamera[0][2], /Cseti\/LTX2\.3-22B_IC-LoRA-Cameraman_v2/);
+  assert.match(MODEL_ASSETS.upscale[0][2], /AInVFX\/SeedVR2_comfyUI/);
+  assert.match(MODEL_ASSETS.upscale[1][2], /numz\/SeedVR2_comfyUI/);
+  assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxGemmaLora')[2], /Comfy-Org\/ltx-2/);
+  assert.match(MODEL_ASSETS.ltxEdit[0][2], /Alissonerdx\/EditAnything/);
+  assert.ok(MODEL_ASSETS.wan.filter((asset) => /Unet$/.test(asset[0]))
+    .every((asset) => /Comfy-Org\/Wan_2\.2_ComfyUI_Repackaged/.test(asset[2])));
+  assert.match(MODEL_ASSETS.eros.find((asset) => asset[0] === 'erosTextEncoder')[2], /gemma_3_12B_it_heretic_fp8_e4m3fn/);
   assert.deepEqual(COMPONENTS.ltxcamera.nodes, ['ltxvideo', 'vhs']);
   assert.deepEqual(COMPONENTS.ltxdirector.nodes, ['whatdreamscost', 'ltxvideo', 'kjnodes', 'vhs']);
   assert.equal(COMPONENTS.video.nodes.includes('whatdreamscost'), false);
@@ -83,67 +95,70 @@ test('dependency catalog covers every enabled image and video family', () => {
   assert.match(MODEL_ASSETS.klein9.find((asset) => asset[0] === 'klein9ConsistencyLora')[2], /f2k_9B_lcs_consist_20260415\.safetensors/);
 });
 
-test('the unavailable regional source fails before changing ComfyUI and reuses a manual install', async () => {
+test('regional prompting installs the reviewed mirror and reuses a compatible legacy checkout', async () => {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-regional-source-'));
   const customNodesPath = path.join(rootDir, 'custom_nodes');
-  const nodePath = path.join(customNodesPath, NODE_PACKS.regional.folder);
+  const preferredPath = path.join(customNodesPath, NODE_PACKS.regional.folder);
+  const legacyPath = path.join(customNodesPath, NODE_PACKS.regional.compatibleFolders[0]);
   const commands = [];
   try {
-    await assert.rejects(
-      installNodePack(NODE_PACKS.regional, {
-        customNodesPath, basePath: rootDir, pythonPath: 'python',
-      }, () => {}, {
-        run: async (...args) => { commands.push(args); return ''; },
-      }),
-      (error) => error.code === 'dependency_node_source_unavailable'
-        && error.failedNode === NODE_PACKS.regional.folder
-        && /will not substitute an unreviewed custom node/.test(error.message)
-    );
-    assert.equal(commands.length, 0);
-    assert.equal(fs.existsSync(customNodesPath), false);
+    await installNodePack(NODE_PACKS.regional, {
+      customNodesPath, basePath: rootDir, pythonPath: 'python',
+    }, () => {}, {
+      run: async (command, args) => {
+        commands.push([command, args]);
+        if (args[0] === 'clone') fs.mkdirSync(path.join(preferredPath, '.git'), { recursive: true });
+        return '';
+      },
+    });
+    assert.deepEqual(commands, [
+      ['git', ['clone', NODE_PACKS.regional.repo, preferredPath]],
+      ['git', ['-C', preferredPath, 'checkout', '--detach', NODE_PACKS.regional.ref]],
+    ]);
 
-    fs.mkdirSync(nodePath, { recursive: true });
-    fs.writeFileSync(path.join(nodePath, '__init__.py'), '# trusted manual regional-node fixture\n');
+    fs.rmSync(preferredPath, { recursive: true, force: true });
+    fs.mkdirSync(path.join(legacyPath, '.git'), { recursive: true });
+    fs.writeFileSync(path.join(legacyPath, 'krea2_regional_multilora_v3.py'),
+      'class Krea2RegionalMultiLoRAV3:\n    pass\nNODE_CLASS_MAPPINGS = {}\n');
+    commands.length = 0;
     const reports = [];
     await installNodePack(NODE_PACKS.regional, {
       customNodesPath, basePath: rootDir, pythonPath: 'python',
     }, (phase, message, detail) => reports.push({ phase, message, detail }), {
-      run: async (...args) => { commands.push(args); return ''; },
+      run: async (command, args) => {
+        commands.push([command, args]);
+        if (args.includes('get-url')) return 'https://github.com/legacy/compatible-regional-node.git';
+        return '';
+      },
     });
-    assert.equal(commands.length, 0);
+    assert.equal(commands.length, 1);
     assert.equal(reports[0].phase, 'existing-node');
-    assert.equal(reports[0].detail.unmanaged, true);
+    assert.equal(reports[0].detail.compatibleMirror, true);
   } finally {
     fs.rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
-test('a mixed advanced install preflights the unavailable regional source before other work', async () => {
-  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-regional-preflight-'));
-  const customNodesPath = path.join(rootDir, 'custom_nodes');
-  const pythonPath = path.join(rootDir, '.venv', 'bin', 'python');
+test('uv is bootstrapped into the ComfyUI Python environment with a clear failure code', async () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-uv-bootstrap-'));
+  const pythonPath = path.join(rootDir, 'python.exe');
   const commands = [];
-  let fetched = false;
   try {
-    fs.mkdirSync(customNodesPath, { recursive: true });
-    fs.mkdirSync(path.dirname(pythonPath), { recursive: true });
-    fs.writeFileSync(path.join(rootDir, 'main.py'), '# ComfyUI fixture\n');
-    fs.writeFileSync(pythonPath, '');
+    const result = await ensureUv({ pythonPath, basePath: rootDir }, () => {}, {
+      existsSync: () => false,
+      run: async (...args) => { commands.push(args); return ''; },
+    });
+    assert.equal(result, path.join(rootDir, 'uv.exe'));
+    assert.deepEqual(commands[0][0], pythonPath);
+    assert.deepEqual(commands[0][1], ['-m', 'pip', 'install', '--upgrade-strategy', 'only-if-needed', 'uv']);
+
     await assert.rejects(
-      installComponents({
-        runtime: { dataDir: path.join(rootDir, 'data'), comfy: { path: rootDir, modelsPath: path.join(rootDir, 'models') } },
-        settings: {},
-        components: ['smartmask', 'regional'],
-        options: {
-          run: async (...args) => { commands.push(args); return ''; },
-          fetch: async () => { fetched = true; throw new Error('should not fetch'); },
-        },
+      ensureUv({ pythonPath, basePath: rootDir }, () => {}, {
+        existsSync: () => false,
+        run: async () => { throw new Error('pip is unavailable'); },
       }),
-      (error) => error.code === 'dependency_node_source_unavailable'
+      (error) => error.code === 'dependency_uv_missing' && /pip is unavailable/.test(error.message)
     );
-    assert.equal(commands.length, 0);
-    assert.equal(fetched, false);
-    assert.equal(fs.existsSync(path.join(customNodesPath, NODE_PACKS.sam3.folder)), false);
   } finally {
     fs.rmSync(rootDir, { recursive: true, force: true });
   }
@@ -210,6 +225,71 @@ test('dependency paths stay inside ComfyUI model folders and trusted repos compa
   assert.equal(sameRepo('https://github.com/example/other.git', 'https://github.com/PozzettiAndrea/ComfyUI-SAM3.git'), false);
   assert.equal(modelIsRegistered('krea2_turbo_fp8_scaled.safetensors', new Set(['Krea2_Turbo_FP8_Scaled.safetensors'])), true);
   assert.equal(modelIsRegistered('Wan2.1\\model.safetensors', new Set(['wan2.1/model.safetensors'])), true);
+  assert.equal(modelIsRegistered('model.safetensors', new Set(['shared/models/model.safetensors'])), true);
+  assert.equal(modelIsRegistered('model.safetensors', new Set(['a/model.safetensors', 'b/model.safetensors'])), false);
+});
+
+test('reviewed model mirrors and Hugging Face tokens are used without exposing the token', async () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-model-fallback-'));
+  const bytes = safetensorsFixture();
+  const urls = [];
+  const headers = [];
+  try {
+    const result = await downloadAsset(
+      ['ltxGemmaLora', 'loras', 'https://huggingface.co/example/model/resolve/main/primary.safetensors', 'model.safetensors', ['https://huggingface.co/example/model/resolve/main/fallback.safetensors']],
+      rootDir,
+      {},
+      () => {},
+      {
+        hfToken: 'hf_test_secret',
+        fetch: async (url, options) => {
+          urls.push(url);
+          headers.push(options.headers);
+          if (urls.length === 1) return { ok: false, status: 404, body: null, text: async () => 'gone' };
+          let sent = false;
+          return {
+            ok: true,
+            status: 200,
+            headers: { get: (name) => name === 'content-length' ? String(bytes.length) : '' },
+            body: { getReader: () => ({ read: async () => sent ? { done: true } : (sent = true, { done: false, value: bytes }) }) },
+          };
+        },
+      }
+    );
+    assert.equal(result.skipped, false);
+    assert.deepEqual(urls, [
+      'https://huggingface.co/example/model/resolve/main/primary.safetensors',
+      'https://huggingface.co/example/model/resolve/main/fallback.safetensors',
+    ]);
+    assert.equal(headers[0].Authorization, 'Bearer hf_test_secret');
+    assert.equal(headers[1].Authorization, 'Bearer hf_test_secret');
+    assert.match(server, /delete response\.hfToken/);
+    assert.match(server, /hfTokenConfigured: !!String\(settings\.hfToken/);
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test('LTXVideo is patched for the kornia 0.8.3 pad relocation', async () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-ltx-kornia-'));
+  const file = path.join(rootDir, 'pyramid_blending.py');
+  try {
+    fs.writeFileSync(file, [
+      'import torch',
+      'from kornia.geometry.transform.pyramid import (',
+      '    pyrdown,',
+      '    pad,',
+      ')',
+      '',
+    ].join('\r\n'));
+    assert.equal(await patchLtxVideoKornia(rootDir), true);
+    const patched = fs.readFileSync(file, 'utf8');
+    assert.match(patched, /from torch\.nn\.functional import pad/);
+    assert.doesNotMatch(patched, /^\s+pad,$/m);
+    assert.equal(await patchLtxVideoKornia(rootDir), false);
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
 test('gated Hugging Face downloads expose only their reviewed repository access page', async () => {
@@ -481,6 +561,9 @@ test('dependency routes run asynchronously and publish progress instead of holdi
   assert.match(server, /\.\.\.EMPTY_DEPENDENCY_FAILURE/);
   assert.match(server, /broadcast\('dependencyInstall'/);
   assert.match(server, /await assertDesktopIsIdle\(\)/);
+  assert.match(server, /const socketStale = socketOpen && Date\.now\(\) - lastWsMessageAt > 15_000/);
+  assert.match(server, /needsTextReconciliation[\s\S]*\['enhance', 'motionPrompt', 'smartMask'\]/);
+  assert.match(server, /comfyFetch\(`\/history\/\$\{pid\}`\)/);
   assert.match(server, /qwenedit: \['qwen'\]/);
   assert.match(server, /klein: \['klein4', 'klein9'\]/);
   assert.match(server, /NODE_PACKS: DEPENDENCY_NODE_PACKS/);
@@ -564,7 +647,9 @@ test('node installs preserve unrelated ComfyUI packages and make a repair explic
 });
 
 test('model readiness accepts ComfyUI DynamicCombo option lists', () => {
-  assert.match(server, /spec\[0\] === 'COMBO' && Array\.isArray\(spec\[1\]\?\.options\)/);
+  const loader = fs.readFileSync(path.join(root, 'lib', 'model-loader.js'), 'utf8');
+  assert.match(loader, /spec\[0\] === 'COMBO' && Array\.isArray\(spec\[1\]\?\.options\)/);
+  assert.match(server, /adoptRegisteredModelPaths\(info\)/);
   assert.match(server, /consistencyLora: modelStatus\(info, 'LoraLoaderModelOnly', 'lora_name', settings\.klein4ConsistencyLora/);
   assert.match(server, /consistencyLora: modelStatus\(info, 'LoraLoaderModelOnly', 'lora_name', settings\.klein9ConsistencyLora/);
 });

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -37,6 +37,7 @@ test('installer manifest exposes optional edit and video components', () => {
   assert.ok(ids.includes('edit.qwen'));
   assert.ok(ids.includes('video.ltxEdit'));
   assert.ok(ids.includes('video.eros'));
+  assert.ok(ids.includes('video.rife'));
   assert.ok(ids.includes('video.scail'));
   const core = manifest.features.find((feature) => feature.id === 'core.image');
   assert.equal(core.models.includes('krea2-raw'), false);

--- a/test/input-assets.test.js
+++ b/test/input-assets.test.js
@@ -56,4 +56,7 @@ test('uploaded inputs are stored locally, streamed to ComfyUI, and served with r
   assert.match(serverSource, /const durable = inputAssetPath\(INPUTS, comfyName\)/);
   assert.match(serverSource, /return serveFile\(res, local, req\.headers\.range\)/);
   assert.match(serverSource, /older inputs fall back to ComfyUI/);
+  assert.match(serverSource, /for \(let attempt = 0; attempt < 2; attempt \+= 1\) \{\s*const upload = await multipartFileUpload\(file, filename\)/);
+  assert.match(serverSource, /Could not upload \$\{filename\} to ComfyUI: \$\{String\(error\.message \|\| error\)\}/);
+  assert.match(serverSource, /wrapped\.code = 'comfy_connection_failed'/);
 });

--- a/test/model-loader.test.js
+++ b/test/model-loader.test.js
@@ -5,7 +5,13 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
-const { diffusionModelInput, diffusionModelLoader, isGgufModel } = require('../lib/model-loader');
+const {
+  diffusionModelInput,
+  diffusionModelLoader,
+  isGgufModel,
+  registeredModelNames,
+  resolveRegisteredModelName,
+} = require('../lib/model-loader');
 
 const root = path.join(__dirname, '..');
 
@@ -22,6 +28,23 @@ test('diffusion model loader selects the node required by the file format', () =
   assert.deepEqual(diffusionModelInput('model.gguf'), {
     className: 'UnetLoaderGGUF', field: 'unet_name',
   });
+});
+
+test('registered model paths resolve unique subfoldered basenames', () => {
+  const names = registeredModelNames({
+    UNETLoader: { input: { required: { unet_name: [['krea\\krea2.safetensors'], {}] } } },
+    LoraLoader: { input: { required: { lora_name: ['COMBO', { options: ['Krea\\turbo.safetensors'] }] } } },
+  });
+  assert.deepEqual(names, ['krea\\krea2.safetensors', 'Krea\\turbo.safetensors']);
+  assert.equal(resolveRegisteredModelName('krea2.safetensors', names), 'krea\\krea2.safetensors');
+  assert.equal(resolveRegisteredModelName('KREA/turbo.safetensors', names), 'Krea\\turbo.safetensors');
+  assert.equal(resolveRegisteredModelName('missing.safetensors', names), '');
+});
+
+test('ambiguous duplicate basenames are not selected automatically', () => {
+  const names = ['first\\shared.safetensors', 'second/shared.safetensors'];
+  assert.equal(resolveRegisteredModelName('shared.safetensors', names), '');
+  assert.equal(resolveRegisteredModelName('second/shared.safetensors', names), 'second/shared.safetensors');
 });
 
 test('image and video graph builders route configured GGUF models through UnetLoaderGGUF', () => {

--- a/test/regional-workflows.test.js
+++ b/test/regional-workflows.test.js
@@ -136,6 +136,8 @@ test('regional text-to-image graph uses Krea2 regional node and Ideogram prompt 
   });
 
   assert.equal(graph.prompt_builder.class_type, 'Ideogram4PromptBuilderKJ');
+  assert.equal(graph.prompt_builder.inputs.import_mode, 'when empty');
+  assert.equal(graph.prompt_builder.inputs.output_format, 'compact');
   assert.deepEqual(graph.regional.inputs.bboxes, ['prompt_builder', 2]);
   assert.equal(graph.regional.class_type, 'Krea2RegionalMultiLoRAV3');
   assert.equal(graph.regional.inputs.split_mode, 'bbox');
@@ -210,6 +212,9 @@ test('Krea2 inpaint can condition directly on the surrounding source image', () 
   assert.match(graph.pos.inputs.text, /Seamlessly integrate/);
   assert.deepEqual(graph.pos.inputs.image1, ['source', 0]);
   assert.equal(graph.pos.inputs.image1_tokens, 'high');
+  assert.equal(graph.pos.inputs.refocus_strength, 0.8);
+  assert.equal(graph.pos.inputs.guidance_strength, 0.5);
+  assert.equal(graph.pos.inputs.enable_split, true);
   assert.deepEqual(graph.composite.inputs.destination, ['source', 0]);
   assert.deepEqual(graph.composite.inputs.mask, ['grow_mask', 0]);
 });

--- a/test/settings-autosave-ui.test.js
+++ b/test/settings-autosave-ui.test.js
@@ -46,7 +46,7 @@ test('a pending app restart appears contextually beside the close button', () =>
 test('only a changed ComfyUI URL currently requests a Mix Studio restart', () => {
   assert.match(server, /const APP_RESTART_SETTINGS_AT_BOOT = Object\.freeze\(\{ comfyUrl: settings\.comfyUrl \}\)/);
   assert.match(server, /function settingsRequireAppRestart\(\) \{\s*return settings\.comfyUrl !== APP_RESTART_SETTINGS_AT_BOOT\.comfyUrl;\s*\}/);
-  assert.match(server, /function settingsResponse\(\) \{\s*return Object\.assign\(\{\}, settings, \{ appRestartRequired: settingsRequireAppRestart\(\) \}\);\s*\}/);
+  assert.match(server, /function settingsResponse\(\) \{[\s\S]*hfTokenConfigured:[\s\S]*delete response\.hfToken;\s*return response;\s*\}/);
   const getRoute = server.slice(server.indexOf("route === '/api/settings' && req.method === 'GET'"), server.indexOf("route === '/api/setup/status'"));
   const postRoute = server.slice(server.indexOf("route === '/api/settings' && req.method === 'POST'"), server.indexOf("route === '/api/meta'"));
   assert.match(getRoute, /settingsResponse\(\)/);


### PR DESCRIPTION
## Summary

Fixes a set of ComfyUI compatibility failures caused by newer model layouts, custom-node dependencies and schemas, authenticated model downloads, and stale transport state.

- **Model detection:** centralizes model discovery, normalizes slash/case differences, resolves a unique basename to ComfyUI's exact registered subfolder path, and adopts that path in saved settings. Ambiguous duplicate basenames are intentionally left for the user to choose.
- **Dependency installer:** updates reviewed model sources, adds the required 10S and RIFE node packs, restores automatic regional-node installation with signature-checked compatible mirrors, ensures `uv` is available, applies the LTXVideo kornia compatibility adjustment, and supports reviewed download fallbacks.
- **Workflow schemas:** supplies the current Ideogram prompt-builder fields and Krea2 Edit Rebalance inputs expected by installed node versions, while including RIFE in setup and readiness checks.
- **Hugging Face token:** adds an owner-configured read token, passes it through both dependency-install paths, sends it only to Hugging Face, and never returns the saved secret to the browser.
- **WebSocket recovery:** wraps connection failures with actionable errors, detects stale ComfyUI sockets, restarts the transport, and reconciles text-producing jobs through history polling.
- **Large uploads:** retries transient ComfyUI upload failures after resetting transport and recreates streamed multipart bodies so large-file retries do not reuse a consumed stream; exact content lengths and clearer filename-specific errors are retained.

## Root cause and impact

The app assumed bare model filenames, older custom-node repositories and input schemas, environment-only Hugging Face authentication, and an open WebSocket that always remained healthy. Those assumptions could report installed models as missing, fail dependency setup or graph validation, strand completed jobs, and make large uploads fail permanently after a transient ComfyUI disconnect.

This change makes setup and generation compatible with current ComfyUI registrations and node packs while preserving explicit choices when model filenames are ambiguous.

## Validation

- `node --check server.js`
- Syntax checks for every changed JavaScript file
- `node --test` — 809 passing, 0 failing
