### PR TITLE
Fix LTX text encoder download

### DIFF
--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -109,7 +109,7 @@ const MODEL_ASSETS = Object.freeze({
   ltx: [
     ['ltxCkpt', 'checkpoints', hf('Lightricks/LTX-2.3-fp8', 'ltx-2.3-22b-dev-fp8.safetensors')],
     ['ltxDistilledLora', 'loras', hf('Lightricks/LTX-2.3', 'ltx-2.3-22b-distilled-lora-384.safetensors')],
-    ['ltxTextEncoder', 'text_encoders', hf('Lightricks/LTX-2.3', 'gemma_3_12B_it_fp4_mixed.safetensors')],
+    ['ltxTextEncoder', 'text_encoders', hf('Comfy-Org/ltx-2', 'split_files/text_encoders/gemma_3_12B_it_fp4_mixed.safetensors')],
     ['ltxGemmaLora', 'loras', hf('Comfy-Org/ltx-2', 'split_files/loras/gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors'), undefined, [hf('Lightricks/LTX-2.3', 'gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors')]],
     ['ltxUpscaler', 'latent_upscale_models', hf('Lightricks/LTX-2.3', 'ltx-2.3-spatial-upscaler-x2-1.1.safetensors')],
   ],

--- a/test/dependency-manager.test.js
+++ b/test/dependency-manager.test.js
@@ -76,6 +76,7 @@ test('dependency catalog covers every enabled image and video family', () => {
   assert.match(MODEL_ASSETS.ltxCamera[0][2], /Cseti\/LTX2\.3-22B_IC-LoRA-Cameraman_v2/);
   assert.match(MODEL_ASSETS.upscale[0][2], /AInVFX\/SeedVR2_comfyUI/);
   assert.match(MODEL_ASSETS.upscale[1][2], /numz\/SeedVR2_comfyUI/);
+  assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxTextEncoder')[2], /Comfy-Org\/ltx-2\/resolve\/main\/split_files\/text_encoders\/gemma_3_12B_it_fp4_mixed\.safetensors/);
   assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxGemmaLora')[2], /Comfy-Org\/ltx-2/);
   assert.match(MODEL_ASSETS.ltxEdit[0][2], /Alissonerdx\/EditAnything/);
   assert.ok(MODEL_ASSETS.wan.filter((asset) => /Unet$/.test(asset[0]))


### PR DESCRIPTION
## Summary

- point the LTX 2.3 FP4 Gemma text encoder download at the maintained Comfy-Org split-file asset
- add regression coverage for the complete resolved Hugging Face URL

## Root cause and impact

The installer still referenced the former Lightricks repository root after the encoder moved to `Comfy-Org/ltx-2/split_files/text_encoders`. Fresh LTX setup therefore failed while downloading `gemma_3_12B_it_fp4_mixed.safetensors`.

## Validation

- `node --check server.js`
- `node --check lib/dependency-installer.js`
- `node --check test/dependency-manager.test.js`
- `node --test test/dependency-manager.test.js` — 25 passing
- `node --test` — 809 passing

Fixes #4
