### PR TITLE
Support ComfyUI numeric union widget types

### DIFF
--- a/server.js
+++ b/server.js
@@ -1505,7 +1505,8 @@ function isWidgetSpec(spec) {
   const t = spec[0];
   if (Array.isArray(t)) return true; // combo
   if (typeof t === 'string' && t.startsWith('COMFY_') && t.includes('COMBO')) return true; // V3 DynamicCombo
-  return ['INT', 'FLOAT', 'STRING', 'BOOLEAN', 'COMBO'].includes(t);
+  const widgetTypes = ['INT', 'FLOAT', 'STRING', 'BOOLEAN', 'COMBO'];
+  return typeof t === 'string' && t.split(',').every((type) => widgetTypes.includes(type));
 }
 
 /**

--- a/test/faceid-lipsync.test.js
+++ b/test/faceid-lipsync.test.js
@@ -4,10 +4,20 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const root = path.join(__dirname, '..');
 const app = fs.readFileSync(path.join(root, 'public', 'app.js'), 'utf8');
 const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
+
+test('empty LTX audio recognizes ComfyUI numeric union widgets', () => {
+  const source = server.match(/function isWidgetSpec\(spec\) \{[\s\S]*?\n\}/)?.[0];
+  assert.ok(source);
+  const isWidgetSpec = vm.runInNewContext(`(${source})`);
+
+  assert.equal(isWidgetSpec(['FLOAT,INT', { default: 25 }]), true);
+  assert.equal(isWidgetSpec(['SAM3_TRACK_DATA,MASK', {}]), false);
+});
 
 test('Face ID freezes an uploaded voice into the audio latent (identity-locked lipsync)', () => {
   // The shared frozen-audio chain: LoadAudio → LTXVAudioVAEEncode →


### PR DESCRIPTION
## Summary
- recognize comma-separated widget unions when every member is a supported widget type
- preserve connection unions such as `SAM3_TRACK_DATA,MASK` as non-widget inputs
- add regression coverage for the `LTXVEmptyLatentAudio.frame_rate` schema

## Problem
ComfyUI 0.29 exposes `LTXVEmptyLatentAudio.frame_rate` as `FLOAT,INT`. `isWidgetSpec()` only recognized exact single type names, so `nodeFromOrdered()` omitted `frame_rate` and ComfyUI rejected LTX prompts with `required_input_missing`.

This affects empty-audio paths used by standard LTX 2.3, Face ID, and 10Eros.

## Verification
- `node --check server.js`
- `node --test test/faceid-lipsync.test.js test/dependency-manager.test.js` (36 passed)
- broad Node test suite excluding the existing NAS-sensitive isolated-server timing case
- live ComfyUI validation and execution of `LTXVEmptyLatentAudio` with `frames_number=97`, `frame_rate=25`, and `batch_size=1`

## Deployment note
A live installation currently runs this exact commit on `main`. Using a normal merge commit will keep that checkout fast-forwardable; squash or rebase merging changes the commit identity and would require a one-time local branch realignment.