### PR TITLE
Bound LTX video memory and preflight stable updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Kept LoRA sliders and hold-drag strength controls within the practical `0–2` range while retaining exact manual entry from `-100` to `100`.
 - Made Mix Packs available from Create, Edit, and video prompt fields, including preset-card persistence, gallery metadata, and image or video documentation exports.
+- Bounded temporal VAE decoding across LTX 2.3, Face ID, Director, and 10Eros, and moved video decoding to a standalone VAE so long renders can release checkpoint dependencies before decode.
+- Made the in-app updater preflight the exact published stable tag in a temporary worktree before changing the live installation.
 
 ## 1.0.3 - 2026-07-30
 

--- a/docs/installation-and-operations.md
+++ b/docs/installation-and-operations.md
@@ -59,13 +59,13 @@ Low VRAM mode never silently changes a request. If an image exceeds roughly one 
 | --- | ---: | ---: | --- |
 | Flux 2 Klein 4B edit | 4 GB | 16 GB | Official FP8 checkpoint with system-RAM offload |
 | Krea 2 image and Krea-based edit | 8 GB | 16 GB | FP8, or native INT8 ConvRot below 16 GB |
-| LTX 2.3, LTX Edit, and 10Eros | 8 GB | 24 GB | Combined FP8 checkpoints with aggressive offload |
+| LTX 2.3, LTX Edit, and 10Eros | 8 GB | 24 GB | FP8 checkpoints, standalone video VAE, and aggressive offload |
 | Wan 2.2 14B and SCAIL 2 | 8 GB | 24 GB | FP8, or manually configured GGUF diffusion weights |
 | Klein 9B and Qwen Edit | 16 GB | 24 GB | Curated BF16 or FP8 variants, or manually configured GGUF weights |
 
 Lower resolution or duration, ComfyUI offloading, and manually configured quantized weights can allow some workflows below their listed tier, with slower generation and a greater out-of-memory risk. Mix Studio warns before a below-tier install or generation and lets the user continue unchanged.
 
-Configured `.gguf` diffusion models automatically use the ComfyUI-GGUF loader in supported Klein, Qwen, Wan, and SCAIL graphs. Guided setup installs that loader but does not download third-party GGUF weights or quantized text encoders. LTX 2.3 and 10Eros use combined audio and video checkpoints and cannot use a transformer-only GGUF file as a drop-in replacement. Krea 2 INT8 ConvRot is not GGUF and uses ComfyUI's standard diffusion loader.
+Configured `.gguf` diffusion models automatically use the ComfyUI-GGUF loader in supported Klein, Qwen, Wan, and SCAIL graphs. Guided setup installs that loader but does not download third-party GGUF weights or quantized text encoders. LTX 2.3 and 10Eros use combined transformer and audio checkpoints plus a standalone BF16 video VAE for bounded temporal decoding; a transformer-only GGUF file is not a drop-in replacement. Krea 2 INT8 ConvRot is not GGUF and uses ComfyUI's standard diffusion loader.
 
 ## ComfyUI and shared models
 
@@ -119,7 +119,9 @@ Open Mix Studio's side menu and choose **Update app**. Updates require:
 - no uncommitted tracked application changes; and
 - idle Mix Studio and ComfyUI queues.
 
-Machine-specific `install.json` and all `data/` content are ignored by Git, so normal updates do not replace profiles, settings, metadata, or generations. Server-side changes restart the Node process automatically. Frontend-only changes reload without a server restart.
+The updater installs the exact stable Git tag advertised by the official GitHub Release instead of pulling unreleased changes from the tip of `main`. Before changing the live branch, it checks the release out separately and runs the server and browser syntax checks plus the full automated test suite. A download, ancestry, or test failure leaves the installed revision unchanged.
+
+Machine-specific `install.json` and all `data/` content are ignored by Git, so normal updates do not replace profiles, settings, metadata, or generations. Server-side changes restart the Node process automatically. Frontend-only changes reload without a server restart. Keep development changes in a separate worktree and contribute reusable fixes upstream so the production checkout remains eligible for one-click fast-forward updates.
 
 Mix Studio checks the official `BlackMixture/Mix-Studio` GitHub Releases channel when a profile signs in and every six hours while the app stays open. A newer stable semantic version appears in the **Updates inbox** with release notes and an optional browser alert. The check is read-only, cached locally for one hour, and uses no bundled GitHub credentials. The local owner still decides when to install the update.
 

--- a/docs/portable-install.md
+++ b/docs/portable-install.md
@@ -25,7 +25,7 @@ The curated Krea 2 image route uses 8 GB VRAM as its guided offload tier and rec
 
 Low VRAM mode is guidance, not a hidden cap. Image requests above roughly one megapixel or batch one receive a confirmation that offers safer settings or the exact original request. LTX 2.3, LTX Edit, 10Eros, Wan 2.2 14B, and SCAIL 2 use 8 GB VRAM as an experimental offload tier and recommend 24 GB VRAM. System RAM is not used as an installation requirement. Shorter duration, smaller frames, native ComfyUI offloading, and supported GGUF weights for Wan and SCAIL improve the chance of success. Hardware below the guided tier still receives an install-anyway option rather than a block.
 
-Klein, Qwen, Wan, and SCAIL graphs switch to `UnetLoaderGGUF` when their configured diffusion filename ends in `.gguf`, and their setup groups install ComfyUI-GGUF. Guided downloads still use the curated safetensors/FP8 files, so third-party GGUF weights must be downloaded and selected manually. The current LTX 2.3 and 10Eros graphs use combined checkpoints; transformer-only GGUF files are not drop-in replacements for those pipelines.
+Klein, Qwen, Wan, and SCAIL graphs switch to `UnetLoaderGGUF` when their configured diffusion filename ends in `.gguf`, and their setup groups install ComfyUI-GGUF. Guided downloads still use the curated safetensors/FP8 files, so third-party GGUF weights must be downloaded and selected manually. The current LTX 2.3 and 10Eros graphs use combined transformer and audio checkpoints plus a standalone video VAE; transformer-only GGUF files are not drop-in replacements for those pipelines.
 
 ## Phone-first access with Tailscale
 

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -63,7 +63,7 @@ Curated workflow families include:
 - ComfyUI-Krea2Edit and Krea2-Regional-MultiLoRA
 - Flux 2 Klein 4B and 9B
 - Qwen Image Edit 2511
-- LTX 2.3, its spatial upscaler, and Gemma encoder
+- LTX 2.3, its standalone video VAE, spatial upscaler, and Gemma encoder
 - Wan 2.2, 10Eros, and SCAIL 2 with SAM3 multiplex and `clip_vision_h`
 - Best-FaceID LoRA and [ComfyUI-BFSNodes](https://github.com/alisson-anjos/ComfyUI-BFSNodes)
 - SeedVR2, KJNodes, VideoHelperSuite, ComfyUI-Frame-Interpolation with RIFE, and Ultimate SD Upscale

--- a/lib/app-update.js
+++ b/lib/app-update.js
@@ -2,12 +2,14 @@
 
 const { execFile } = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const APP_RELEASE_FILE = 'release.json';
 const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const DIRTY_FILE_LIMIT = 8;
 const DIRTY_PATH_LIMIT = 240;
+const UPDATE_CHECK_TIMEOUT_MS = 5 * 60 * 1000;
 
 function isValidIsoDate(value) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
@@ -49,6 +51,57 @@ function gitCommand(root, args, options = {}) {
       reject(wrapped);
     });
   });
+}
+
+function processCommand(executable, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(executable, args, {
+      cwd: options.cwd,
+      windowsHide: true,
+      timeout: options.timeout || UPDATE_CHECK_TIMEOUT_MS,
+      maxBuffer: 4 * 1024 * 1024,
+    }, (error, stdout, stderr) => {
+      if (!error) return resolve(String(stdout || ''));
+      const detail = String(stderr || stdout || error.message || 'Release verification failed').trim();
+      const wrapped = new Error(detail.slice(-1200));
+      wrapped.code = 'update_preflight';
+      reject(wrapped);
+    });
+  });
+}
+
+function stableReleaseVersion(tag) {
+  const value = String(tag || '').trim();
+  if (!value.startsWith('v')) return null;
+  return normalizeAppRelease({ version: value.slice(1), releasedAt: '' }).version;
+}
+
+async function verifyReleaseWorktree(root, target, expectedVersion, options = {}) {
+  if (typeof options.verifyRelease === 'function') {
+    return options.verifyRelease({ root, target, expectedVersion });
+  }
+  const runGit = options.runGit;
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'mix-studio-update-'));
+  const checkout = path.join(parent, 'checkout');
+  let added = false;
+  try {
+    await runGit(['worktree', 'add', '--detach', checkout, target]);
+    added = true;
+    const release = readAppRelease(checkout);
+    if (release.version !== expectedVersion) {
+      const error = new Error(`Release tag v${expectedVersion} contains version ${release.version || 'unknown'}.`);
+      error.code = 'update_release';
+      throw error;
+    }
+    const node = options.nodeExecutable || process.execPath;
+    await processCommand(node, ['--check', 'server.js'], { cwd: checkout });
+    await processCommand(node, ['--check', 'public/app.js'], { cwd: checkout });
+    await processCommand(node, ['--test'], { cwd: checkout });
+    return { release };
+  } finally {
+    if (added) await runGit(['worktree', 'remove', '--force', checkout]).catch(() => {});
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
 }
 
 // The repository was renamed KreaStudio -> Mix-Studio. GitHub redirects the
@@ -155,13 +208,46 @@ async function updateFromGit(root, options = {}) {
 
   const releaseBefore = normalizeAppRelease(await readRelease());
   const before = (await runGit(['rev-parse', 'HEAD'])).trim();
-  const pullOutput = (await runGit(['pull', '--ff-only', 'origin', branch])).trim();
+  const targetTag = String(options.targetTag || '').trim();
+  let pullOutput;
+  let preflightPassed = false;
+  if (targetTag) {
+    const targetVersion = stableReleaseVersion(targetTag);
+    if (!targetVersion || (options.targetVersion && options.targetVersion !== targetVersion)) {
+      const error = new Error('The published update does not have a valid matching stable release tag.');
+      error.code = 'update_release';
+      throw error;
+    }
+    const tagRef = `refs/tags/${targetTag}`;
+    await runGit(['fetch', '--no-tags', 'origin', `${tagRef}:${tagRef}`]);
+    const target = (await runGit(['rev-parse', `${tagRef}^{commit}`])).trim();
+    const base = (await runGit(['merge-base', before, target])).trim();
+    if (base !== before && base !== target) {
+      const error = new Error('This installation has local commits that diverge from the published release. Reconcile them once before automatic updates can continue.');
+      error.code = 'update_diverged';
+      throw error;
+    }
+    if (base === before && before !== target) {
+      await verifyReleaseWorktree(root, target, targetVersion, {
+        runGit,
+        verifyRelease: options.verifyRelease,
+        nodeExecutable: options.nodeExecutable,
+      });
+      preflightPassed = true;
+      pullOutput = (await runGit(['merge', '--ff-only', target])).trim();
+    } else {
+      pullOutput = 'Already at or ahead of the latest published release.';
+    }
+  } else {
+    pullOutput = (await runGit(['pull', '--ff-only', 'origin', branch])).trim();
+  }
   const after = (await runGit(['rev-parse', 'HEAD'])).trim();
   const release = normalizeAppRelease(await readRelease());
   if (before === after) {
     return {
       updated: false, restartRequired: false, branch, before, after,
       releaseBefore, release, changedFiles: [], pullOutput, originMigrated: origin.migrated,
+      targetTag: targetTag || null, preflightPassed,
     };
   }
 
@@ -180,6 +266,8 @@ async function updateFromGit(root, options = {}) {
     changedFiles,
     pullOutput,
     originMigrated: origin.migrated,
+    targetTag: targetTag || null,
+    preflightPassed,
   };
 }
 
@@ -189,6 +277,7 @@ module.exports = {
   isValidIsoDate,
   gitCommand,
   normalizeAppRelease,
+  stableReleaseVersion,
   readAppRelease,
   restartRequiredForFiles,
   migrateLegacyOrigin,
@@ -197,5 +286,6 @@ module.exports = {
   CURRENT_ORIGIN,
   DIRTY_FILE_LIMIT,
   parseDirtyStatus,
+  verifyReleaseWorktree,
   updateFromGit,
 };

--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -143,6 +143,7 @@ const MODEL_ASSETS = Object.freeze({
   ],
   ltx: [
     ['ltxCkpt', 'checkpoints', hf('Lightricks/LTX-2.3-fp8', 'ltx-2.3-22b-dev-fp8.safetensors')],
+    ['ltxVideoVae', 'vae', hf('Kijai/LTX2.3_comfy', 'vae/LTX23_video_vae_bf16.safetensors')],
     ['ltxDistilledLora', 'loras', hf('Lightricks/LTX-2.3', 'ltx-2.3-22b-distilled-lora-384.safetensors')],
     ['ltxTextEncoder', 'text_encoders', hf('Comfy-Org/ltx-2', 'split_files/text_encoders/gemma_3_12B_it_fp4_mixed.safetensors')],
     ['ltxGemmaLora', 'loras', hf('Comfy-Org/ltx-2', 'split_files/loras/gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors'), undefined, [hf('Lightricks/LTX-2.3', 'gemma-3-12b-it-abliterated_lora_rank64_bf16.safetensors')]],
@@ -172,7 +173,7 @@ const MODEL_ASSETS = Object.freeze({
   eros: [
     ['erosCkpt', 'checkpoints', hf('Tridae/ErosDeployment_ComfyUI', 'checkpoints/10Eros_v1.2_fp8mixed_learned.safetensors')],
     ['erosTextEncoder', 'text_encoders', hf('Tridae/ErosDeployment_ComfyUI', 'text_encoders/gemma_3_12B_it_heretic_fp8_e4m3fn.safetensors')],
-    ['erosDmdLora', 'loras', hf('Tridae/ErosDeployment_ComfyUI', 'loras/LTX2.3_DMD_reshaped_r256.safetensors')],
+    ['erosDmdLora', 'loras', hf('TenStrip/LTX2.3_DMD_Lora', 'LTX2.3_DMD_reshaped_r256.safetensors')],
   ],
   scail: [
     ['scailUnet', 'diffusion_models', hf('Comfy-Org/SCAIL-2', 'diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors')],

--- a/lib/ltx-director-workflows.js
+++ b/lib/ltx-director-workflows.js
@@ -373,6 +373,7 @@ async function buildLtxDirectorGraph(project, opts, settings, helpers) {
   }
 
   graph.ckpt = { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: settings.ltxCkpt } };
+  graph.video_vae = { class_type: 'VAELoader', inputs: { vae_name: settings.ltxVideoVae } };
   graph.model_lora = {
     class_type: 'LoraLoaderModelOnly',
     inputs: { model: ['ckpt', 0], lora_name: settings.ltxDistilledLora, strength_model: 0.5 },
@@ -433,7 +434,7 @@ async function buildLtxDirectorGraph(project, opts, settings, helpers) {
   const guideInputs = (positive, negative, latent, scaleBy) => ({
     positive,
     negative,
-    vae: ['ckpt', 2],
+    vae: ['video_vae', 0],
     latent,
     guide_data: ['director', 4],
     motion_guide_data: ['director', 5],
@@ -456,7 +457,7 @@ async function buildLtxDirectorGraph(project, opts, settings, helpers) {
     graph.extension_guide_base = await nodeFromOrdered(
       'LTXVImgToVideoInplace',
       [0.95, false],
-      { vae: ['ckpt', 2], image: ['extension_tail_prep', 0], latent: baseLatent },
+      { vae: ['video_vae', 0], image: ['extension_tail_prep', 0], latent: baseLatent },
     );
     baseLatent = ['extension_guide_base', 0];
   }
@@ -483,7 +484,7 @@ async function buildLtxDirectorGraph(project, opts, settings, helpers) {
   graph.ups_model = { class_type: 'LatentUpscaleModelLoader', inputs: { model_name: settings.ltxUpscaler } };
   graph.ups = {
     class_type: 'LTXVLatentUpsampler',
-    inputs: { samples: ['crop1', 2], upscale_model: ['ups_model', 0], vae: ['ckpt', 2] },
+    inputs: { samples: ['crop1', 2], upscale_model: ['ups_model', 0], vae: ['video_vae', 0] },
   };
   graph.guide_refine = { class_type: 'LTXDirectorGuide', inputs: guideInputs(['crop1', 0], ['crop1', 1], ['ups', 0], 1) };
   let refineLatent = ['guide_refine', 2];
@@ -491,7 +492,7 @@ async function buildLtxDirectorGraph(project, opts, settings, helpers) {
     graph.extension_guide_refine = await nodeFromOrdered(
       'LTXVImgToVideoInplace',
       [1, false],
-      { vae: ['ckpt', 2], image: ['extension_tail_prep', 0], latent: refineLatent },
+      { vae: ['video_vae', 0], image: ['extension_tail_prep', 0], latent: refineLatent },
     );
     refineLatent = ['extension_guide_refine', 0];
   }
@@ -514,7 +515,7 @@ async function buildLtxDirectorGraph(project, opts, settings, helpers) {
     class_type: 'LTXDirectorCropGuides',
     inputs: { positive: ['guide_refine', 0], negative: ['guide_refine', 1], latent: ['sep2', 0] },
   };
-  graph.decode = await nodeFromOrdered('VAEDecodeTiled', [768, 64, 4096, 4], { samples: ['crop2', 2], vae: ['ckpt', 2] });
+  graph.decode = await nodeFromOrdered('VAEDecodeTiled', [768, 64, 64, 8], { samples: ['crop2', 2], vae: ['video_vae', 0] });
   graph.audio_dec = { class_type: 'LTXVAudioVAEDecode', inputs: { samples: ['sep2', 1], audio_vae: ['audio_vae', 0] } };
   let frameSource = ['decode', 0];
   frameSource = await rifeSmooth(graph, frameSource, opts.smooth);

--- a/public/app.js
+++ b/public/app.js
@@ -2160,8 +2160,8 @@ $('#appUpdateBtn').addEventListener('click', async () => {
   appUpdateRunning = true;
   button.disabled = true;
   button.classList.add('busy');
-  label.textContent = 'Checking for updates…';
-  setAppUpdateStatus('Connecting to GitHub and checking the current branch…');
+  label.textContent = 'Testing stable update…';
+  setAppUpdateStatus('Downloading the published release and running its safety checks…');
   try {
     const previousInstanceId = state.appRelease.instanceId;
     const result = await api('/api/update', { method: 'POST' });
@@ -25103,7 +25103,7 @@ const SETTINGS_SERVER_CONTROL_IDS = new Set([
   'setKlein4Unet', 'setKlein4Clip', 'setKlein4ConsistencyLora', 'setKlein4ConsistencyTrigger',
   'setKlein9Unet', 'setKlein9Clip', 'setKlein9ConsistencyLora', 'setKlein9ConsistencyTrigger',
   'setKleinVae', 'setQeUnet', 'setQeClip', 'setQeLora', 'setQeAnglesLora',
-  'setDit', 'setSvVae', 'setSysPrompt', 'setLtxCkpt', 'setLtxLora',
+  'setDit', 'setSvVae', 'setSysPrompt', 'setLtxCkpt', 'setLtxVideoVae', 'setLtxLora',
   'setLtxCameraLora', 'setLtxEditLora', 'setLtxDirectorLora', 'setLtxTe',
   'setLtxGemmaLora', 'setLtxUps', 'setFaceIdLora', 'setFaceIdDistilled',
   'setWanHigh', 'setWanLow', 'setWanClip', 'setWanVae', 'setWanHighLora',
@@ -25163,6 +25163,7 @@ function settingsPayload() {
     seedvr2Attention: $('#setSvAttn').value,
     systemPrompt: $('#setSysPrompt').value,
     ltxCkpt: $('#setLtxCkpt').value,
+    ltxVideoVae: $('#setLtxVideoVae').value,
     ltxDistilledLora: $('#setLtxLora').value,
     ltxCameramanLora: $('#setLtxCameraLora').value,
     ltxEditLora: $('#setLtxEditLora').value,
@@ -28537,6 +28538,7 @@ $('#settingsBtn').addEventListener('click', async () => {
     setSvAttnValue(s.seedvr2Attention || 'sdpa');
     $('#setSysPrompt').value = s.systemPrompt || '';
     $('#setLtxCkpt').value = s.ltxCkpt || '';
+    $('#setLtxVideoVae').value = s.ltxVideoVae || '';
     $('#setLtxLora').value = s.ltxDistilledLora || '';
     $('#setLtxCameraLora').value = s.ltxCameramanLora || '';
     $('#setLtxEditLora').value = s.ltxEditLora || '';

--- a/public/index.html
+++ b/public/index.html
@@ -2484,6 +2484,7 @@
           <div class="settings-pane-head"><h4>Video Models</h4><p>LTX, Wan, 10Eros, and SCAIL pipelines.</p></div>
           <div class="settings-group"><h5>LTX 2.3 &amp; Face ID</h5>
             <div class="field"><label>LTX checkpoint</label><input id="setLtxCkpt" type="text" /></div>
+            <div class="field"><label>Video VAE</label><input id="setLtxVideoVae" type="text" /></div>
             <div class="field"><label>Distilled LoRA</label><input id="setLtxLora" type="text" /></div>
             <div class="field"><label>Camera Motion IC-LoRA</label><input id="setLtxCameraLora" type="text" /></div>
             <div class="field"><label>Edit Anything LoRA</label><input id="setLtxEditLora" type="text" /></div>

--- a/server.js
+++ b/server.js
@@ -379,6 +379,7 @@ const DEFAULT_SETTINGS = {
   qwenEditLora: 'Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors',
   qwenEditAnglesLora: 'qwen_image_edit_2511_multiple-angles-lora.safetensors',
   ltxCkpt: 'ltx-2.3-22b-dev-fp8.safetensors',
+  ltxVideoVae: 'LTX23_video_vae_bf16.safetensors',
   ltxDistilledLora: 'ltx-2.3-22b-distilled-lora-384.safetensors',
   ltxCameramanLora: 'LTX2.3-22B_IC-LoRA-Cameraman_v2_14000.safetensors',
   ltxEditLora: 'edit_anything_v1.1_r256.safetensors',
@@ -1337,6 +1338,7 @@ function configuredModelsStatus(info) {
     ltx: {
       label: 'LTX 2.3',
       checkpoint: modelStatus(info, 'CheckpointLoaderSimple', 'ckpt_name', settings.ltxCkpt),
+      videoVae: modelStatus(info, 'VAELoader', 'vae_name', settings.ltxVideoVae),
       distilled: modelStatus(info, 'LoraLoaderModelOnly', 'lora_name', settings.ltxDistilledLora, loraList),
       textEncoder: modelStatusAny(info, settings.ltxTextEncoder, [['LTXAVTextEncoderLoader', 'text_encoder']]),
       gemmaLora: modelStatus(info, 'LoraLoader', 'lora_name', settings.ltxGemmaLora, loraList),
@@ -3594,6 +3596,7 @@ async function buildAnimate(imageName, opts) {
 
   // Models
   graph.ckpt = { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: settings.ltxCkpt } };
+  graph.video_vae = { class_type: 'VAELoader', inputs: { vae_name: settings.ltxVideoVae } };
   graph.model_lora = {
     class_type: 'LoraLoaderModelOnly',
     inputs: { model: ['ckpt', 0], lora_name: settings.ltxDistilledLora, strength_model: 0.5 },
@@ -3734,7 +3737,7 @@ async function buildAnimate(imageName, opts) {
     graph.camera_image_condition1 = await nodeFromOrdered(
       'LTXVImgToVideoConditionOnly',
       [0.5, !!opts.bypass],
-      { vae: ['ckpt', 2], image: ['prep', 0], latent: ['latent1', 0] }
+      { vae: ['video_vae', 0], image: ['prep', 0], latent: ['latent1', 0] }
     );
     graph.camera_guide1 = await nodeFromOrdered(
       'LTXAddVideoICLoRAGuide',
@@ -3742,7 +3745,7 @@ async function buildAnimate(imageName, opts) {
       {
         positive: basePositive,
         negative: baseNegative,
-        vae: ['ckpt', 2],
+        vae: ['video_vae', 0],
         latent: ['camera_image_condition1', 0],
         image: cameraGuideSource,
       }
@@ -3754,7 +3757,7 @@ async function buildAnimate(imageName, opts) {
     graph.edit_guide1 = {
       class_type: 'LTXVAddGuide',
       inputs: {
-        positive: basePositive, negative: baseNegative, vae: ['ckpt', 2], latent: ['latent1', 0],
+        positive: basePositive, negative: baseNegative, vae: ['video_vae', 0], latent: ['latent1', 0],
         image: ['edit_source_base', 0], frame_idx: 0, strength: 1,
       },
     };
@@ -3765,7 +3768,7 @@ async function buildAnimate(imageName, opts) {
     graph.i2v1 = {
       class_type: 'LTXVImgToVideoInplaceKJ',
       inputs: {
-        vae: ['ckpt', 2], latent: ['latent1', 0],
+        vae: ['video_vae', 0], latent: ['latent1', 0],
         num_images: '2',
         'num_images.strength_1': 0.95, 'num_images.image_1': ['prep', 0], 'num_images.index_1': 0,
         'num_images.strength_2': 0.95, 'num_images.image_2': ['prep_end', 0], 'num_images.index_2': opts.frames - 1,
@@ -3776,7 +3779,7 @@ async function buildAnimate(imageName, opts) {
     graph.i2v1 = await nodeFromOrdered(
       'LTXVImgToVideoInplace',
       [0.95, !!opts.bypass],
-      { vae: ['ckpt', 2], image: ['prep', 0], latent: ['latent1', 0] }
+      { vae: ['video_vae', 0], image: ['prep', 0], latent: ['latent1', 0] }
     );
     baseLatent = ['i2v1', 0];
   }
@@ -3812,7 +3815,7 @@ async function buildAnimate(imageName, opts) {
   graph.ups_model = { class_type: 'LatentUpscaleModelLoader', inputs: { model_name: settings.ltxUpscaler } };
   graph.ups = {
     class_type: 'LTXVLatentUpsampler',
-    inputs: { samples: ['sep1', 0], upscale_model: ['ups_model', 0], vae: ['ckpt', 2] },
+    inputs: { samples: ['sep1', 0], upscale_model: ['ups_model', 0], vae: ['video_vae', 0] },
   };
   let refinePositive;
   let refineNegative;
@@ -3825,7 +3828,7 @@ async function buildAnimate(imageName, opts) {
     graph.camera_image_condition2 = await nodeFromOrdered(
       'LTXVImgToVideoConditionOnly',
       [0.7, !!opts.bypass],
-      { vae: ['ckpt', 2], image: ['prep', 0], latent: ['ups', 0] }
+      { vae: ['video_vae', 0], image: ['prep', 0], latent: ['ups', 0] }
     );
     refinePositive = ['camera_crop1', 0];
     refineNegative = ['camera_crop1', 1];
@@ -3840,7 +3843,7 @@ async function buildAnimate(imageName, opts) {
     graph.edit_guide2 = {
       class_type: 'LTXVAddGuide',
       inputs: {
-        positive: ['edit_crop1', 0], negative: ['edit_crop1', 1], vae: ['ckpt', 2], latent: ['ups', 0],
+        positive: ['edit_crop1', 0], negative: ['edit_crop1', 1], vae: ['video_vae', 0], latent: ['ups', 0],
         image: ['edit_source', 0], frame_idx: 0, strength: 1,
       },
     };
@@ -3851,7 +3854,7 @@ async function buildAnimate(imageName, opts) {
     graph.i2v2 = {
       class_type: 'LTXVImgToVideoInplaceKJ',
       inputs: {
-        vae: ['ckpt', 2], latent: ['ups', 0],
+        vae: ['video_vae', 0], latent: ['ups', 0],
         num_images: '2',
         'num_images.strength_1': 1, 'num_images.image_1': ['prep', 0], 'num_images.index_1': 0,
         'num_images.strength_2': 1, 'num_images.image_2': ['prep_end', 0], 'num_images.index_2': opts.frames - 1,
@@ -3862,7 +3865,7 @@ async function buildAnimate(imageName, opts) {
     graph.i2v2 = await nodeFromOrdered(
       'LTXVImgToVideoInplace',
       [1, !!opts.bypass],
-      { vae: ['ckpt', 2], image: ['prep', 0], latent: ['ups', 0] }
+      { vae: ['video_vae', 0], image: ['prep', 0], latent: ['ups', 0] }
     );
     refineLatent = ['i2v2', 0];
   }
@@ -3897,8 +3900,8 @@ async function buildAnimate(imageName, opts) {
   // Decode + mux
   graph.decode = await nodeFromOrdered(
     'VAEDecodeTiled',
-    [768, 64, 4096, 4],
-    { samples: ['sep2', 0], vae: ['ckpt', 2] }
+    [768, 64, 64, 8],
+    { samples: ['sep2', 0], vae: ['video_vae', 0] }
   );
   graph.audio_dec = {
     class_type: 'LTXVAudioVAEDecode',
@@ -3955,6 +3958,7 @@ async function buildAnimateFaceId(faceName, opts) {
 
   // Models: base ckpt -> distilled-1.1 @0.6 -> FaceID LoRA @1.0 -> user LoRAs
   graph.ckpt = { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: settings.ltxCkpt } };
+  graph.video_vae = { class_type: 'VAELoader', inputs: { vae_name: settings.ltxVideoVae } };
   graph.model_lora = {
     class_type: 'LoraLoaderModelOnly',
     inputs: { model: ['ckpt', 0], lora_name: settings.ltxFaceIdDistilledLora, strength_model: 0.6 },
@@ -4040,7 +4044,7 @@ async function buildAnimateFaceId(faceName, opts) {
       model: ltxModel,
       positive: ['cond', 0],
       negative: ['cond', 1],
-      vae: ['ckpt', 2],
+      vae: ['video_vae', 0],
       latent: ['concat1', 0],
       reference_face: ['face', 0],
     }
@@ -4069,8 +4073,8 @@ async function buildAnimateFaceId(faceName, opts) {
   };
   graph.decode = await nodeFromOrdered(
     'VAEDecodeTiled',
-    [768, 64, 4096, 4],
-    { samples: ['crop', 2], vae: ['ckpt', 2] }
+    [768, 64, 64, 8],
+    { samples: ['crop', 2], vae: ['video_vae', 0] }
   );
   graph.audio_dec = {
     class_type: 'LTXVAudioVAEDecode',
@@ -4149,8 +4153,10 @@ async function buildAnimateEros(imageName, opts) {
   const halfW = Math.max(64, Math.round(opts.W / 2 / 32) * 32);
   const halfH = Math.max(64, Math.round(opts.H / 2 / 32) * 32);
 
-  // Models (checkpoint provides transformer + video VAE + audio VAE)
+  // The checkpoint provides the transformer and audio VAE. A standalone video
+  // VAE lets ComfyUI release checkpoint dependencies before the tiled decode.
   graph.ckpt = { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: settings.erosCkpt } };
+  graph.video_vae = { class_type: 'VAELoader', inputs: { vae_name: settings.ltxVideoVae } };
   graph.audio_vae = { class_type: 'LTXVAudioVAELoader', inputs: { ckpt_name: settings.erosCkpt } };
   graph.te = await nodeFromOrdered(
     'LTXAVTextEncoderLoader',
@@ -4254,7 +4260,7 @@ async function buildAnimateEros(imageName, opts) {
     audioLatent = ['audio_lat', 0];
   }
   const i2v1Inputs = {
-    vae: ['ckpt', 2], latent: ['latent1', 0],
+    vae: ['video_vae', 0], latent: ['latent1', 0],
     num_images: opts.endImageName ? '2' : '1',
     'num_images.strength_1': 1,
     'num_images.image_1': ['prep', 0],
@@ -4273,7 +4279,7 @@ async function buildAnimateEros(imageName, opts) {
   graph.ref1 = {
     class_type: 'LTXReferenceConditioning',
     inputs: {
-      model: erosModel, vae: ['ckpt', 2], image: ['resize_half', 0],
+      model: erosModel, vae: ['video_vae', 0], image: ['resize_half', 0],
       target_latent: ['i2v1', 0], strength: 1, position_mode: 'reference', verbose: false,
     },
   };
@@ -4294,10 +4300,10 @@ async function buildAnimateEros(imageName, opts) {
   graph.ups_model = { class_type: 'LatentUpscaleModelLoader', inputs: { model_name: settings.ltxUpscaler } };
   graph.ups = {
     class_type: 'LTXVLatentUpsampler',
-    inputs: { samples: ['sep1', 0], upscale_model: ['ups_model', 0], vae: ['ckpt', 2] },
+    inputs: { samples: ['sep1', 0], upscale_model: ['ups_model', 0], vae: ['video_vae', 0] },
   };
   const i2v2Inputs = {
-    vae: ['ckpt', 2], latent: ['ups', 0],
+    vae: ['video_vae', 0], latent: ['ups', 0],
     num_images: opts.endImageName ? '2' : '1',
     'num_images.strength_1': 1,
     'num_images.image_1': ['resize_full', 0],
@@ -4316,7 +4322,7 @@ async function buildAnimateEros(imageName, opts) {
   graph.ref2 = {
     class_type: 'LTXReferenceConditioning',
     inputs: {
-      model: erosModel, vae: ['ckpt', 2], image: ['resize_full', 0],
+      model: erosModel, vae: ['video_vae', 0], image: ['resize_full', 0],
       target_latent: ['i2v2', 0], strength: 1, position_mode: 'reference', verbose: false,
     },
   };
@@ -4333,7 +4339,11 @@ async function buildAnimateEros(imageName, opts) {
   graph.sep2 = { class_type: 'LTXVSeparateAVLatent', inputs: { av_latent: ['second', 1] } };
 
   // Decode + mux
-  graph.decode = { class_type: 'VAEDecode', inputs: { samples: ['sep2', 0], vae: ['ckpt', 2] } };
+  graph.decode = await nodeFromOrdered(
+    'VAEDecodeTiled',
+    [768, 64, 64, 8],
+    { samples: ['sep2', 0], vae: ['video_vae', 0] }
+  );
   graph.audio_dec = {
     class_type: 'LTXVAudioVAEDecode',
     inputs: { samples: ['sep2', 1], audio_vae: ['audio_vae', 0] },
@@ -4961,7 +4971,7 @@ const REQUIRED_CLASSES = {
   smartmask: SAM3_MASK_CLASSES,
   upscale: ['SeedVR2LoadDiTModel', 'SeedVR2LoadVAEModel', 'SeedVR2VideoUpscaler'],
   ultimateupscale: ['UltimateSDUpscale', 'UpscaleModelLoader'],
-  video: ['CheckpointLoaderSimple', 'LoraLoaderModelOnly', 'LTXAVTextEncoderLoader', 'TextGenerateLTX2Prompt',
+  video: ['CheckpointLoaderSimple', 'VAELoader', 'LoraLoaderModelOnly', 'LTXAVTextEncoderLoader', 'TextGenerateLTX2Prompt',
     'LTXVConditioning', 'EmptyLTXVLatentVideo', 'LTXVImgToVideoInplace', 'LTXVAudioVAELoader',
     'LTXVEmptyLatentAudio', 'LTXVConcatAVLatent', 'LTXVSeparateAVLatent', 'RandomNoise', 'CFGGuider',
     'KSamplerSelect', 'ManualSigmas', 'SamplerCustomAdvanced', 'LatentUpscaleModelLoader',
@@ -4975,11 +4985,11 @@ const REQUIRED_CLASSES = {
   rife: ['RIFE VFI'],
   wan: ['UNETLoader', 'CLIPLoader', 'VAELoader', 'LoraLoaderModelOnly', 'ModelSamplingSD3',
     'WanImageToVideo', 'KSamplerAdvanced', 'VAEDecode', 'CreateVideo', 'SaveVideo'],
-  eros: ['CheckpointLoaderSimple', 'LTXVAudioVAELoader', 'LTXAVTextEncoderLoader', 'ImageResizeKJv2',
+  eros: ['CheckpointLoaderSimple', 'VAELoader', 'LTXVAudioVAELoader', 'LTXAVTextEncoderLoader', 'ImageResizeKJv2',
     'LTXVPreprocess', 'LTXReferenceEnable', 'LTXReferenceConditioning', 'LoraLoaderModelOnly',
     'EmptyLTXVLatentVideo', 'LTXVEmptyLatentAudio', 'LTXVImgToVideoInplaceKJ', 'LTXVConcatAVLatent',
     'EchoDMDSigmas', 'EchoDMDSigmaRemap', 'EchoDMDSampler', 'SamplerCustom', 'LTXVSeparateAVLatent',
-    'LatentUpscaleModelLoader', 'LTXVLatentUpsampler', 'ManualSigmas', 'VAEDecode', 'LTXVAudioVAEDecode',
+    'LatentUpscaleModelLoader', 'LTXVLatentUpsampler', 'ManualSigmas', 'VAEDecodeTiled', 'LTXVAudioVAEDecode',
     'CreateVideo', 'SaveVideo'],
   scail: ['UNETLoader', 'CLIPLoader', 'VAELoader', 'LoraLoaderModelOnly', 'ModelSamplingSD3',
     'CLIPVisionLoader', 'CLIPVisionEncode', 'CheckpointLoaderSimple', 'CLIPTextEncode', 'ImageScale',
@@ -5487,9 +5497,18 @@ async function handleApi(req, res, url) {
       // Enter maintenance before the first queue check so another browser
       // cannot submit work while the network-bound fast-forward is running.
       await assertDesktopIsIdle();
+      const installedRelease = readAppRelease(ROOT);
+      const publishedRelease = await officialReleaseChecker.check(installedRelease.version);
+      if (!publishedRelease.latest?.tagName) {
+        const error = new Error('No published stable Mix Studio release is available.');
+        error.code = 'update_release';
+        throw error;
+      }
       const update = await updateFromGit(ROOT, {
         channel: RUNTIME.update.channel,
         gitExecutable: RUNTIME.update.gitExecutable,
+        targetTag: publishedRelease.latest.tagName,
+        targetVersion: publishedRelease.latest.version,
       });
       // ComfyUI can receive work outside Mix Studio. Check it again directly
       // before scheduling a process restart. If that race occurs after Git has
@@ -5518,6 +5537,8 @@ async function handleApi(req, res, url) {
         releasedAt: update.release.releasedAt,
         revision: update.after.slice(0, 7),
         changedFiles: update.changedFiles,
+        tested: update.preflightPassed,
+        releaseTag: update.targetTag,
       });
       if (update.updated && update.restartRequired) {
         if (waitingForIdle) scheduleServerRestartWhenIdle();
@@ -5525,7 +5546,7 @@ async function handleApi(req, res, url) {
       }
       return;
     } catch (e) {
-      const status = ['desktop_busy', 'update_dirty', 'update_branch', 'update_channel', 'update_origin'].includes(e.code) ? 409 : 500;
+      const status = ['desktop_busy', 'update_dirty', 'update_branch', 'update_channel', 'update_origin', 'update_release', 'update_diverged'].includes(e.code) ? 409 : 500;
       const payload = { error: String(e.message || e), code: e.code || 'update_failed' };
       if (e.code === 'update_dirty' && Array.isArray(e.dirtyFiles)) {
         payload.dirtyFiles = e.dirtyFiles;

--- a/test/app-update-ui.test.js
+++ b/test/app-update-ui.test.js
@@ -125,13 +125,15 @@ test('drawer selections use black borders against the drawer canvas', () => {
   assert.match(css, /\.app-drawer-create-item\.active \{[^}]*border-color: #000;/);
 });
 
-test('the update flow pulls safely and waits for a conditional restart', () => {
+test('the update flow pre-tests a stable release and waits for a conditional restart', () => {
   assert.match(server, /route === '\/api\/update'/);
   assert.match(server, /updateFromGit\(ROOT,\s*\{/);
+  assert.match(server, /publishedRelease\.latest\.tagName/);
   assert.match(server, /await assertDesktopIsIdle\(\)/);
   assert.match(server, /appUpdateRunning/);
   assert.match(app, /waitForAppRestart/);
   assert.match(app, /api\('\/api\/update'/);
+  assert.match(app, /Downloading the published release and running its safety checks/);
 });
 
 test('an external ComfyUI job that starts after the pull delays, but does not strand, the restart', () => {

--- a/test/app-update.test.js
+++ b/test/app-update.test.js
@@ -11,6 +11,7 @@ const {
   readAppRelease,
   restartRequiredForFiles,
   isOfficialOrigin,
+  stableReleaseVersion,
   updateFromGit,
 } = require('../lib/app-update');
 
@@ -64,6 +65,12 @@ test('release metadata accepts SemVer and rejects ambiguous version labels', () 
   }
 });
 
+test('stable updates accept only exact v-prefixed semantic release tags', () => {
+  assert.equal(stableReleaseVersion('v1.2.3'), '1.2.3');
+  assert.equal(stableReleaseVersion('v2.0.0-beta.1'), '2.0.0-beta.1');
+  for (const tag of ['1.2.3', 'v1.2', 'latest', 'main', '']) assert.equal(stableReleaseVersion(tag), null);
+});
+
 test('release metadata is read from disk on every call and safely handles missing files', (t) => {
   const root = temporaryReleaseRoot(t);
   assert.deepEqual(readAppRelease(root), { version: null, releasedAt: null });
@@ -105,6 +112,71 @@ test('updates report the release metadata from before and after the fast-forward
   assert.deepEqual(result.release, releases[1]);
   assert.equal(result.restartRequired, false);
   assert.deepEqual(result.changedFiles, ['release.json', 'public/app.js']);
+});
+
+test('stable updates verify the exact published tag before fast-forwarding', async () => {
+  const fake = gitSequence([
+    '', 'main\n', 'https://github.com/BlackMixture/Mix-Studio.git\n', 'aaa\n',
+    '', 'bbb\n', 'aaa\n', 'Updating aaa..bbb\n', 'bbb\n', 'server.js\n',
+  ]);
+  const releases = [
+    { version: '1.0.2', releasedAt: '2026-07-24' },
+    { version: '1.0.3', releasedAt: '2026-07-30' },
+  ];
+  let releaseReads = 0;
+  const verified = [];
+  const result = await updateFromGit('/app', {
+    runGit: fake.runGit,
+    targetTag: 'v1.0.3',
+    targetVersion: '1.0.3',
+    readRelease: () => releases[releaseReads++],
+    verifyRelease: async (details) => verified.push(details),
+  });
+
+  assert.equal(result.updated, true);
+  assert.equal(result.preflightPassed, true);
+  assert.equal(result.targetTag, 'v1.0.3');
+  assert.deepEqual(verified, [{ root: '/app', target: 'bbb', expectedVersion: '1.0.3' }]);
+  assert.deepEqual(fake.calls[4], ['fetch', '--no-tags', 'origin', 'refs/tags/v1.0.3:refs/tags/v1.0.3']);
+  assert.deepEqual(fake.calls[5], ['rev-parse', 'refs/tags/v1.0.3^{commit}']);
+  assert.deepEqual(fake.calls[6], ['merge-base', 'aaa', 'bbb']);
+  assert.deepEqual(fake.calls[7], ['merge', '--ff-only', 'bbb']);
+});
+
+test('a failed stable-release preflight leaves the live branch untouched', async () => {
+  const fake = gitSequence([
+    '', 'main\n', 'https://github.com/BlackMixture/Mix-Studio.git\n', 'aaa\n',
+    '', 'bbb\n', 'aaa\n',
+  ]);
+  const error = new Error('tests failed');
+  error.code = 'update_preflight';
+  await assert.rejects(
+    updateFromGit('/app', {
+      runGit: fake.runGit,
+      targetTag: 'v1.0.3',
+      targetVersion: '1.0.3',
+      verifyRelease: async () => { throw error; },
+    }),
+    (caught) => caught.code === 'update_preflight'
+  );
+  assert.equal(fake.calls.some((args) => args[0] === 'merge'), false);
+});
+
+test('stable updates stop instead of guessing across divergent local commits', async () => {
+  const fake = gitSequence([
+    '', 'main\n', 'https://github.com/BlackMixture/Mix-Studio.git\n', 'aaa\n',
+    '', 'bbb\n', 'common\n',
+  ]);
+  await assert.rejects(
+    updateFromGit('/app', {
+      runGit: fake.runGit,
+      targetTag: 'v1.0.3',
+      targetVersion: '1.0.3',
+      verifyRelease: async () => assert.fail('diverged releases must not be tested'),
+    }),
+    (error) => error.code === 'update_diverged'
+  );
+  assert.equal(fake.calls.some((args) => args[0] === 'merge'), false);
 });
 
 test('a legacy KreaStudio origin migrates to Mix-Studio before pulling', async () => {
@@ -198,6 +270,9 @@ test('update and meta APIs expose semantic releases independently of ComfyUI rea
   assert.match(updateRoute, /revision:\s*update\.after\.slice\(0, 7\)/);
   assert.match(updateRoute, /payload\.dirtyFiles\s*=\s*e\.dirtyFiles/);
   assert.match(updateRoute, /payload\.dirtyFileCount/);
+  assert.match(updateRoute, /targetTag:\s*publishedRelease\.latest\.tagName/);
+  assert.match(updateRoute, /targetVersion:\s*publishedRelease\.latest\.version/);
+  assert.match(updateRoute, /tested:\s*update\.preflightPassed/);
 
   const metaRoute = server.slice(server.indexOf("route === '/api/meta'"), server.indexOf("route === '/api/input'"));
   assert.match(metaRoute, /const app = Object\.assign\(readAppRelease\(ROOT\), \{ instanceId: SERVER_INSTANCE_ID \}\)/);

--- a/test/dependency-manager.test.js
+++ b/test/dependency-manager.test.js
@@ -81,6 +81,7 @@ test('dependency catalog covers every enabled image and video family', () => {
   assert.match(MODEL_ASSETS.upscale[0][2], /AInVFX\/SeedVR2_comfyUI/);
   assert.match(MODEL_ASSETS.upscale[1][2], /numz\/SeedVR2_comfyUI/);
   assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxTextEncoder')[2], /Comfy-Org\/ltx-2\/resolve\/main\/split_files\/text_encoders\/gemma_3_12B_it_fp4_mixed\.safetensors/);
+  assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxVideoVae')[2], /Kijai\/LTX2\.3_comfy\/resolve\/main\/vae\/LTX23_video_vae_bf16\.safetensors/);
   assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxGemmaLora')[2], /Comfy-Org\/ltx-2/);
   assert.match(MODEL_ASSETS.ltxEdit[0][2], /Alissonerdx\/EditAnything/);
   const qwenAngles = MODEL_ASSETS.qwen.find((asset) => asset[0] === 'qwenEditAnglesLora');
@@ -93,6 +94,7 @@ test('dependency catalog covers every enabled image and video family', () => {
   assert.ok(MODEL_ASSETS.wan.filter((asset) => /Unet$/.test(asset[0]))
     .every((asset) => /Comfy-Org\/Wan_2\.2_ComfyUI_Repackaged/.test(asset[2])));
   assert.match(MODEL_ASSETS.eros.find((asset) => asset[0] === 'erosTextEncoder')[2], /gemma_3_12B_it_heretic_fp8_e4m3fn/);
+  assert.match(MODEL_ASSETS.eros.find((asset) => asset[0] === 'erosDmdLora')[2], /TenStrip\/LTX2\.3_DMD_Lora/);
   const scailLora = MODEL_ASSETS.scail.find((asset) => asset[0] === 'scailLora');
   assert.match(scailLora[2], /lightx2v\/Wan2\.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/);
   assert.match(scailLora[2], /Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64\.safetensors/);

--- a/test/faceid-lipsync.test.js
+++ b/test/faceid-lipsync.test.js
@@ -9,6 +9,22 @@ const root = path.join(__dirname, '..');
 const app = fs.readFileSync(path.join(root, 'public', 'app.js'), 'utf8');
 const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
 
+test('LTX-family workflows decode long videos in bounded temporal tiles', () => {
+  const ltx = server.slice(server.indexOf('async function buildAnimate(imageName'), server.indexOf('async function buildAnimateFaceId'));
+  const faceId = server.slice(server.indexOf('async function buildAnimateFaceId'), server.indexOf('async function buildAnimateEros'));
+  const eros = server.slice(server.indexOf('async function buildAnimateEros'), server.indexOf('buildAnimateWan'));
+
+  assert.match(ltx, /'VAEDecodeTiled',\s*\[768, 64, 64, 8\]/);
+  assert.match(faceId, /'VAEDecodeTiled',\s*\[768, 64, 64, 8\]/);
+  assert.match(eros, /'VAEDecodeTiled',\s*\[768, 64, 64, 8\]/);
+  for (const workflow of [ltx, faceId, eros]) {
+    assert.match(workflow, /graph\.video_vae = \{ class_type: 'VAELoader'/);
+    assert.match(workflow, /vae: \['video_vae', 0\]/);
+    assert.doesNotMatch(workflow, /vae: \['ckpt', 2\]/);
+  }
+  assert.doesNotMatch(eros, /graph\.decode = \{ class_type: 'VAEDecode'/);
+});
+
 test('Face ID freezes an uploaded voice into the audio latent (identity-locked lipsync)', () => {
   // The shared frozen-audio chain: LoadAudio → LTXVAudioVAEEncode →
   // SolidMask(0.0) → SetLatentNoiseMask. A 0.0 noise mask means the audio

--- a/test/ltx-director-workflows.test.js
+++ b/test/ltx-director-workflows.test.js
@@ -185,6 +185,7 @@ test('Director graph inserts prompt relay and guide nodes into the existing two-
   };
   const settings = {
     ltxCkpt: 'ltx.safetensors',
+    ltxVideoVae: 'ltx-vae.safetensors',
     ltxDistilledLora: 'distilled.safetensors',
     ltxTextEncoder: 'gemma.safetensors',
     ltxGemmaLora: 'gemma-lora.safetensors',
@@ -204,6 +205,7 @@ test('Director graph inserts prompt relay and guide nodes into the existing two-
   assert.equal(graph.guide_base.class_type, 'LTXDirectorGuide');
   assert.equal(graph.guide_base.inputs.scale_by, 0.5);
   assert.equal(graph.guide_refine.inputs.scale_by, 1);
+  assert.equal(graph.video_vae.inputs.vae_name, 'ltx-vae.safetensors');
   assert.equal(graph.crop1.class_type, 'LTXDirectorCropGuides');
   assert.equal(graph.crop2.class_type, 'LTXDirectorCropGuides');
   assert.deepEqual(graph.samp1.inputs.noise, ['noise', 0]);
@@ -232,7 +234,7 @@ test('Director graph keeps LoRAs, guide audio override, smoothing, 4K, and poste
     W: 1280, H: 720, seed: 99, smooth: 2, fourK: true, makePoster: true,
     loras: [{ name: 'look.safetensors', strength: 0.8, on: true }], sigmasBase: '1,0', sigmasRefine: '0.5,0',
   }, {
-    ltxCkpt: 'ltx.safetensors', ltxDistilledLora: 'distilled.safetensors', ltxTextEncoder: 'gemma.safetensors',
+    ltxCkpt: 'ltx.safetensors', ltxVideoVae: 'ltx-vae.safetensors', ltxDistilledLora: 'distilled.safetensors', ltxTextEncoder: 'gemma.safetensors',
     ltxGemmaLora: 'gemma-lora.safetensors', ltxUpscaler: 'up.safetensors', ltxDirectorIcLora: 'ingredients.safetensors',
   }, helpers);
   assert.deepEqual(calls.loras, [{ name: 'look.safetensors', strength: 0.8, on: true }]);
@@ -243,6 +245,8 @@ test('Director graph keeps LoRAs, guide audio override, smoothing, 4K, and poste
   assert.equal(graph.vsr.class_type, 'RTXVideoSuperResolution');
   assert.deepEqual(graph.video.inputs.images, ['vsr', 0]);
   assert.equal(graph.video.inputs.fps, 48);
+  assert.deepEqual(graph.decode.inputs.ordered, [768, 64, 64, 8]);
+  assert.deepEqual(graph.decode.inputs.vae, ['video_vae', 0]);
   assert.equal(graph.poster_save.class_type, 'SaveImage');
 });
 
@@ -277,7 +281,7 @@ test('Director extension anchors both stages and emits a seam-trimmed tail for a
     loras: [], sigmasBase: '1,0', sigmasRefine: '0.5,0',
     extension: { videoName: 'source.mp4', sourceHasAudio: false, plan },
   }, {
-    ltxCkpt: 'ltx.safetensors', ltxDistilledLora: 'distilled.safetensors', ltxTextEncoder: 'gemma.safetensors',
+    ltxCkpt: 'ltx.safetensors', ltxVideoVae: 'ltx-vae.safetensors', ltxDistilledLora: 'distilled.safetensors', ltxTextEncoder: 'gemma.safetensors',
     ltxGemmaLora: 'gemma-lora.safetensors', ltxUpscaler: 'up.safetensors', ltxDirectorIcLora: 'ingredients.safetensors',
   }, helpers);
 

--- a/test/settings-tabs-ui.test.js
+++ b/test/settings-tabs-ui.test.js
@@ -50,7 +50,7 @@ test('model settings retain one field each and follow logical pipeline groups', 
     'setComfy', 'galleryPasswordInput', 'setUnet', 'setKrea2RawUnet', 'setKrea2TurboLora', 'setKrea2DepthLora', 'setDepthAnythingV3Model', 'setClip', 'setVae',
     'setKlein4Unet', 'setKlein4ConsistencyLora', 'setKlein4ConsistencyTrigger',
     'setKlein9Unet', 'setKlein9ConsistencyLora', 'setKlein9ConsistencyTrigger', 'setQeUnet', 'setDit', 'setSvVae',
-    'setLtxCkpt', 'setWanHigh', 'setErosCkpt', 'setScailUnet', 'setSvAttn', 'setSysPrompt',
+    'setLtxCkpt', 'setLtxVideoVae', 'setWanHigh', 'setErosCkpt', 'setScailUnet', 'setSvAttn', 'setSysPrompt',
   ];
   for (const id of ids) {
     assert.equal((html.match(new RegExp(`id="${id}"`, 'g')) || []).length, 1, `${id} should appear once`);


### PR DESCRIPTION
## Summary
- decode standard LTX, Face ID, Director, and 10Eros in bounded temporal tiles
- use a standalone LTX video VAE throughout those graphs so checkpoint dependencies can be released before decode
- install, health-check, document, and expose the standalone VAE in Advanced Settings
- update from the exact published stable tag only after syntax checks and the full test suite pass in a temporary worktree
- reject divergent release ancestry without changing the live installation

## Verification
- `node --check server.js`
- `node --check public/app.js`
- `git diff --check`
- `node --test` (`893/893` passed)
- real temporary-worktree preflight of stable `v1.0.3` passed
- monitored 10Eros render completed at 1280x1280, 289 frames, 24 fps, 12.04 seconds
- monitored standard LTX render completed at 1280x1280, 297 frames, 25 fps, 11.88 seconds; ComfyUI history reported success and the kernel recorded no OOM

## Merge note
A live installation runs this exact commit on local `main`. Please use a normal merge commit so this checkout remains an ancestor of the next release and can use the one-click fast-forward updater. Squash or rebase merging would require one final manual branch realignment.