### PR TITLE
Find models configured through Comfy Desktop

### DIFF
--- a/installer/model-discovery.js
+++ b/installer/model-discovery.js
@@ -45,9 +45,11 @@ function expandPathValue(value, env = process.env) {
     .replace(/^~(?=[\\/]|$)/, env.USERPROFILE || env.HOME || '~');
 }
 
+const BLOCK_SCALAR_RE = /^[|>][-+]?$/;
+
 function resolveConfiguredPath(value, basePath, configDir, pathApi = path, env = process.env) {
   const expanded = expandPathValue(stripYamlScalar(value), env);
-  if (!expanded || expanded === '|' || expanded === '>') return '';
+  if (!expanded || BLOCK_SCALAR_RE.test(expanded)) return '';
   if (pathApi.isAbsolute(expanded)) return pathApi.normalize(expanded);
   return pathApi.resolve(basePath || configDir, expanded);
 }
@@ -101,11 +103,12 @@ function parseExtraModelPaths(text, options = {}) {
       continue;
     }
     block = null;
-    const match = trimmed.match(/^([A-Za-z0-9_.-]+)\s*:\s*(.*)$/);
+    // Comfy Desktop quotes every mapping key in its generated config.
+    const match = trimmed.match(/^(?:'([^']+)'|"([^"]+)"|([A-Za-z0-9_.-]+))\s*:\s*(.*)$/);
     if (!match) continue;
-    const key = match[1];
+    const key = match[1] || match[2] || match[3];
     const lowerKey = key.toLowerCase();
-    const value = stripYamlScalar(match[2]);
+    const value = stripYamlScalar(match[4]);
     if (indent === 0 && !value) {
       section = key;
       currentSection();
@@ -114,7 +117,7 @@ function parseExtraModelPaths(text, options = {}) {
     if (lowerKey === 'base_path') {
       currentSection().basePath = resolveConfiguredPath(value, '', configDir, pathApi, env);
     } else if (MODEL_PATH_KEYS.has(lowerKey)) {
-      if (value === '|' || value === '>') block = { indent, key: lowerKey };
+      if (BLOCK_SCALAR_RE.test(value)) block = { indent, key: lowerKey };
       else if (value) currentSection().entries.push({ key: lowerKey, value });
     }
   }
@@ -136,6 +139,11 @@ function parseExtraModelPaths(text, options = {}) {
   return { roots: [...roots], configuredPaths: [...new Set(configuredPaths)] };
 }
 
+// Comfy Desktop keeps its own model roots outside the ComfyUI checkout, under a
+// different filename, so those must be scanned as well as the classic configs.
+const DESKTOP_CONFIG_DIRS = ['Comfy Desktop', 'ComfyUI'];
+const DESKTOP_CONFIG_FILES = ['shared_model_paths.yaml', 'extra_models_config.yaml'];
+
 function candidateConfigFiles(comfyPath, env = process.env, pathApi = path) {
   const candidates = [];
   const add = (base) => {
@@ -145,7 +153,14 @@ function candidateConfigFiles(comfyPath, env = process.env, pathApi = path) {
   };
   add(comfyPath);
   if (comfyPath) add(pathApi.join(comfyPath, 'ComfyUI'));
-  if (env.APPDATA) add(pathApi.join(env.APPDATA, 'ComfyUI'));
+  if (env.APPDATA) {
+    add(pathApi.join(env.APPDATA, 'ComfyUI'));
+    for (const directory of DESKTOP_CONFIG_DIRS) {
+      for (const file of DESKTOP_CONFIG_FILES) {
+        candidates.push(pathApi.join(env.APPDATA, directory, file));
+      }
+    }
+  }
   return [...new Set(candidates)];
 }
 
@@ -163,6 +178,26 @@ async function registeredModelsFromComfy(comfyUrl, options = {}) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+/** A ComfyUI checkout keeps an empty `models` tree even when every model lives
+ *  in a shared library, so a root that holds no model file must not win the
+ *  destination over one that does. */
+function rootHoldsModels(root, fsApi, pathApi) {
+  if (typeof fsApi.readdirSync !== 'function') return false;
+  const pending = [root];
+  for (let depth = 0; depth < 2 && pending.length; depth += 1) {
+    const directories = pending.splice(0, pending.length);
+    for (const directory of directories) {
+      let entries;
+      try { entries = fsApi.readdirSync(directory, { withFileTypes: true }); } catch { continue; }
+      for (const entry of entries) {
+        if (entry.isDirectory()) pending.push(pathApi.join(directory, entry.name));
+        else if (MODEL_FILE_RE.test(entry.name)) return true;
+      }
+    }
+  }
+  return false;
 }
 
 async function discoverModels(options = {}) {
@@ -190,14 +225,19 @@ async function discoverModels(options = {}) {
   }
   const registry = await registeredModelsFromComfy(options.comfyUrl, options);
   const discoveredRoots = [...roots];
+  const populatedRoots = discoveredRoots.filter((root) => rootHoldsModels(root, fsApi, pathApi));
   return {
     schemaVersion: 1,
     detectedAt: new Date().toISOString(),
     registeredModelNames: registry.names,
     registeredModelCount: registry.names.length,
     modelRoots: discoveredRoots,
+    populatedModelRoots: populatedRoots,
     configFiles,
-    preferredModelsPath: manualModelsPath || discoveredRoots[0] || (comfyPath ? pathApi.join(comfyPath, 'models') : ''),
+    preferredModelsPath: manualModelsPath
+      || populatedRoots[0]
+      || discoveredRoots[0]
+      || (comfyPath ? pathApi.join(comfyPath, 'models') : ''),
     registryError: registry.error,
   };
 }

--- a/server.js
+++ b/server.js
@@ -869,6 +869,20 @@ function applySetupConnection(values) {
   return config;
 }
 
+/** Choosing a ComfyUI folder must not move the model destination away from a
+ *  shared library the user already filled — Comfy Desktop keeps its own models
+ *  folder empty when `extra_model_paths` style config points somewhere else. */
+async function connectedModelsPath(comfyPath) {
+  const fallback = comfyPath ? path.join(comfyPath, 'models') : '';
+  if (!comfyPath) return '';
+  try {
+    const discovery = await discoverModels({ comfyUrl: '', comfyPath });
+    return discovery.preferredModelsPath || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 function startOfficialComfySetup() {
   const script = path.join(ROOT, 'installer', 'install-comfy.ps1');
   if (!fs.existsSync(script)) throw new Error('The official ComfyUI setup helper is missing from this checkout.');
@@ -5593,7 +5607,7 @@ async function handleApi(req, res, url) {
       const requestedPath = String(body.path || '').trim();
       applySetupConnection({
         path: requestedPath,
-        modelsPath: String(body.modelsPath || '').trim() || (requestedPath ? path.join(requestedPath, 'models') : ''),
+        modelsPath: String(body.modelsPath || '').trim() || await connectedModelsPath(requestedPath),
         url: body.url || settings.comfyUrl,
       });
       comfySetupExpectedBasePath = '';

--- a/test/model-discovery.test.js
+++ b/test/model-discovery.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  candidateConfigFiles,
   collectRegisteredModelNames,
   discoverModels,
   parseExtraModelPaths,
@@ -36,6 +37,27 @@ shared:
   loras: Lora
 `, { configDir: 'C:\\ComfyUI', pathApi: path.win32, env: {} });
   assert.ok(parsed.roots.includes('D:\\AI\\Models'));
+});
+
+test('reads the quoted keys and block scalars Comfy Desktop writes', () => {
+  const parsed = parseExtraModelPaths(`
+comfy.desktop_0:
+  base_path: 'C:\\diffusion\\models'
+  is_default: true
+  'checkpoints': 'checkpoints/'
+  'controlnet': |-
+    controlnet/
+    t2i_adapter/
+  'loras': 'loras/'
+`, { configDir: 'C:\\ComfyUI', pathApi: path.win32, env: {} });
+  assert.deepEqual(parsed.roots, ['C:\\diffusion\\models']);
+  assert.ok(parsed.configuredPaths.includes('C:\\diffusion\\models\\t2i_adapter'));
+});
+
+test('scans the Comfy Desktop shared model config alongside classic ComfyUI configs', () => {
+  const files = candidateConfigFiles('C:\\ComfyUI', { APPDATA: 'C:\\Roaming' }, path.win32);
+  assert.ok(files.includes('C:\\Roaming\\Comfy Desktop\\shared_model_paths.yaml'));
+  assert.ok(files.includes('C:\\ComfyUI\\extra_model_paths.yaml'));
 });
 
 test('combines ComfyUI registry discovery with existing model roots', async () => {


### PR DESCRIPTION
## The bug

A model library configured entirely through ComfyUI Desktop is invisible to Mix Studio, and connecting to ComfyUI silently redirects downloads away from it.

Reproduced on a machine whose whole library lives in `C:\diffusion\models`. ComfyUI registered all 1526 model names from it; Mix Studio found none of them and offered to re-download models already on disk.

## Two causes

**1. Discovery never reads Comfy Desktop's config.** Desktop writes its model roots to `shared_model_paths.yaml` under `%APPDATA%\Comfy Desktop\` — a different filename in a different folder than the `extra_model_paths.yaml` that `candidateConfigFiles` looked for. It also writes a dialect the parser rejected:

```yaml
comfy.desktop_0:
  base_path: 'C:\diffusion\models'
  'checkpoints': 'checkpoints/'
  'controlnet': |-
    controlnet/
    t2i_adapter/
```

Every mapping key is quoted, so `/^([A-Za-z0-9_.-]+)\s*:/` never matched, and multi-folder entries use `|-`, which the block-scalar check (`value === '|' || value === '>'`) missed. Both are handled now.

**2. Connecting to ComfyUI overwrites a good path.** `POST /api/setup/connection` defaulted `modelsPath` to `<comfyFolder>\models` whenever the request didn't carry one, so picking a ComfyUI folder replaced an already-configured shared library with the checkout's own (empty) models folder — which ComfyUI doesn't even read when its config points elsewhere. It now runs discovery and prefers a root that actually contains model files.

## Before / after

```
before   roots:     C:\...\ComfyUI-Installs\ComfyUI\ComfyUI\models   (0 model files)
         preferred: C:\...\ComfyUI-Installs\ComfyUI\ComfyUI\models

after    roots:     C:\...\ComfyUI\models, C:\diffusion\models
         populated: C:\diffusion\models
         preferred: C:\diffusion\models
```

## Notes

`rootHoldsModels` walks two levels with the injected `fsApi` and returns `false` when `readdirSync` isn't available, so callers passing a minimal fs stub keep the previous ordering. `discoverModels` gains a `populatedModelRoots` field; `modelRoots` ordering is unchanged.

## Tests

`node --test` green (890). Two added: the Comfy Desktop YAML dialect, and `candidateConfigFiles` covering both config locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)