### PR TITLE
Keep Xet staging paths inside the Windows path limit

### DIFF
--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const fsp = require('fs/promises');
 const path = require('path');
+const crypto = require('crypto');
 const { execFile } = require('child_process');
 const { sam3InstallStatus } = require('./sam3-installer');
 const {
@@ -895,11 +896,16 @@ async function waitForDownloadRetry(attempt, options = {}) {
   });
 }
 
+/** The Hugging Face client nests its own cache (`.cache/huggingface/download/`
+ *  plus the repo sub-path and a ~110 character chunk-hash filename) inside this
+ *  directory. Windows still defaults to a 260 character limit, so a descriptive
+ *  staging name overflows it and the accelerated transfer dies on an unopenable
+ *  `.incomplete` file. A short digest keeps the whole tree addressable. */
 function downloadStagingDirectory(modelsPath, settingKey, sourceUrl) {
   const source = parseHuggingFaceResolveUrl(sourceUrl);
   const sourceKey = source ? `${source.repoId}-${source.revision}-${source.filename}` : sourceUrl;
-  const safe = `${settingKey}-${sourceKey}`.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 180);
-  return path.join(modelsPath, '.mix-studio-downloads', `${safe}.hf-xet`);
+  const digest = crypto.createHash('sha1').update(`${settingKey}-${sourceKey}`).digest('hex').slice(0, 16);
+  return path.join(modelsPath, '.mix-studio-downloads', `${digest}.hf-xet`);
 }
 
 async function downloadAsset(asset, modelsPath, settings, report, options = {}) {
@@ -1484,6 +1490,7 @@ module.exports = {
   dependencyCancelledError,
   dependencyModelPlan,
   downloadAsset,
+  downloadStagingDirectory,
   ensureDownloadDiskSpace,
   findExistingModelByBasename,
   filterProtectedRuntimeRequirements,

--- a/test/dependency-manager.test.js
+++ b/test/dependency-manager.test.js
@@ -19,6 +19,7 @@ const {
   cleanRelative,
   dependencyModelPlan,
   downloadAsset,
+  downloadStagingDirectory,
   ensureDownloadDiskSpace,
   ensureUv,
   findExistingModelByBasename,
@@ -37,6 +38,7 @@ const {
   sameRepo,
   validateModelFile,
 } = require('../lib/dependency-installer');
+const { parseHuggingFaceResolveUrl } = require('../lib/huggingface-download');
 const { comfyPort, restartStatus } = require('../lib/comfy-restart');
 
 function safetensorsFixture() {
@@ -381,6 +383,30 @@ test('large Hugging Face models use isolated Xet acceleration before the HTTP fa
   } finally {
     fs.rmSync(rootDir, { recursive: true, force: true });
   }
+});
+
+test('Xet staging paths leave room for the Hugging Face cache under the Windows path limit', () => {
+  // huggingface_hub nests `.cache/huggingface/download/<repo sub-path>/<chunk>`
+  // inside the staging folder; the chunk name is roughly 110 characters.
+  const chunkName = `${'a'.repeat(28)}.${'b'.repeat(64)}.${'c'.repeat(8)}.incomplete`;
+  const modelsPath = 'C:\\ComfyUI\\models';
+  let longest = 0;
+  for (const assets of Object.values(MODEL_ASSETS)) {
+    for (const asset of assets) {
+      for (const url of [asset[2], ...(Array.isArray(asset[4]) ? asset[4] : [])]) {
+        const source = parseHuggingFaceResolveUrl(url);
+        if (!source) continue;
+        const staging = downloadStagingDirectory(modelsPath, asset[0], url);
+        const cached = path.win32.join(
+          staging, '.cache', 'huggingface', 'download',
+          ...source.filename.split('/').slice(0, -1), chunkName
+        );
+        longest = Math.max(longest, cached.length);
+      }
+    }
+  }
+  assert.ok(longest > 0, 'expected Hugging Face assets to stage downloads');
+  assert.ok(longest < 260, `staging path grew to ${longest} characters, past the Windows limit`);
 });
 
 test('Xet failures fall back to the resumable HTTP downloader', async () => {


### PR DESCRIPTION
## The bug

Xet acceleration fails on **every** model download on Windows and silently falls back to the single-stream HTTP downloader — while the UI keeps reporting `downloadMethod: 'hf-xet'` and "Accelerating … with Hugging Face Xet".

## Cause

`huggingface_hub` nests its own cache inside the staging directory:

```
<staging>/.cache/huggingface/download/<repo sub-path>/<chunk>.incomplete
```

The chunk filename alone is ~110 characters. `downloadStagingDirectory` named the staging folder after a readable description of the asset, capped at 180 characters:

```js
const safe = `${settingKey}-${sourceKey}`.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 180);
```

For `qwenEditUnet` that produced a ~400-character path — well past the 260-character Windows limit. The transfer died opening its `.incomplete` file, `downloadAsset` caught the error and dropped to `http-resume`.

## Observed

On a machine with `LongPathsEnabled=0`:

```
long path    FileNotFoundError: ...\7aIpaFQFY4IjjyXXpv-OyR-zRs8=.d64f3a68...b5d980d5.incomplete
short path   336 MB in 9s (~37 MB/s)
```

The fallback path was the only one that ever ran. Note this is invisible in normal use: downloads still complete, just far slower than intended, and the reported method stays `hf-xet` until the fallback report fires.

## Fix

Name the staging directory after a 16-character SHA-1 digest of the same key. Worst case across all `MODEL_ASSETS` drops from ~400 to **236** characters, verified writable on Windows:

```
C:\diffusion\models\.mix-studio-downloads\e2d4809dbb3e1bce.hf-xet\.cache\huggingface\download\split_files\diffusion_models\<chunk>.incomplete
```

The digest is deterministic, so in-flight staging directories still resume across restarts. Directory names are no longer human-readable, which only affects manual inspection of `.mix-studio-downloads`.

## Tests

`node --test` green (889). Added a test that walks every Hugging Face asset in `MODEL_ASSETS`, reconstructs the nested cache path, and asserts the longest stays under 260 characters — so a new deep-pathed asset can't quietly reintroduce this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)