### PR TITLE
Fix open setup issues and add Apple Silicon support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/pages.yml
       - docs/download/**
       - install_MixStudio.bat
+      - install_MixStudio.command
       - public/mix-studio-logo.svg
       - docs/download/mix-studio-wordmark.svg
   workflow_dispatch:
@@ -48,6 +49,7 @@ jobs:
           mkdir -p _site
           cp docs/download/index.html _site/index.html
           cp install_MixStudio.bat _site/install_MixStudio.bat
+          cp install_MixStudio.command _site/install_MixStudio.command
           cp public/mix-studio-logo.svg _site/mix-studio-logo.svg
           cp docs/download/mix-studio-wordmark.svg _site/mix-studio-wordmark.svg
           cp docs/download/mix-studio-create.webp _site/mix-studio-create.webp

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -87,6 +87,12 @@ jobs:
           call install_MixStudio.bat --verify-checkout "%ProgramFiles%\Git\cmd\git.exe" "%GITHUB_WORKSPACE%"
           if errorlevel 1 exit /b 1
           call install_MixStudio.bat --verify-node "node.exe"
+
+      - name: Check macOS launchers
+        if: runner.os == 'macOS'
+        run: |
+          /bin/zsh -n install_MixStudio.command
+          /bin/zsh -n start.command
 
       - name: Run tests
         run: node --test

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 <p align="center">
   <a href="https://blackmixture.github.io/Mix-Studio/"><img alt="Download for Windows" src="https://img.shields.io/badge/Download-Windows-4285F4?style=flat-square&amp;logo=windows11&amp;logoColor=white" /></a>
+  <a href="https://blackmixture.github.io/Mix-Studio/install_MixStudio.command"><img alt="Download for macOS" src="https://img.shields.io/badge/Download-macOS-111111?style=flat-square&amp;logo=apple&amp;logoColor=white" /></a>
   <a href="https://github.com/BlackMixture/Mix-Studio/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/BlackMixture/Mix-Studio?style=flat-square&amp;label=release" /></a>
   <a href="https://github.com/BlackMixture/Mix-Studio/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/BlackMixture/Mix-Studio?style=flat-square&amp;logo=github" /></a>
   <a href="LICENSE"><img alt="GPLv3 license" src="https://img.shields.io/badge/license-GPLv3-34A853?style=flat-square" /></a>
@@ -20,18 +21,18 @@ Mix Studio is a local web interface that builds and submits ComfyUI API graphs f
 
 Krea 2 editing includes Identity Edit v1.2 and the multi-reference **Krea 2 Remix** workflow, with an advanced Reference boost control for stronger identity and subject guidance.
 
-- **Create from anywhere:** use the same touch-friendly workspace on the Windows desktop, a phone on the same Wi-Fi, or privately through Tailscale.
+- **Create from anywhere:** use the same touch-friendly workspace on the generation computer, a phone on the same Wi-Fi, or privately through Tailscale.
 - **Keep the power of ComfyUI:** reuse your installation, models, custom nodes, queue, and recovery outputs.
 - **Stay local and in control:** prompts, inputs, generated media, profiles, and galleries remain on your computer.
 - **Skip the node graph rebuilds:** work through focused controls while Mix Studio assembles the graph for each job.
 
 ## Quick setup
 
-1. Open the **[Mix Studio download page](https://blackmixture.github.io/Mix-Studio/)** and save `install_MixStudio.bat`.
-2. Put the installer in the parent folder where you want Mix Studio to live, then run it. For example, placing it in `D:\AI` creates `D:\AI\Mix Studio`.
+1. Open the **[Mix Studio download page](https://blackmixture.github.io/Mix-Studio/)** and choose the Windows or macOS installer.
+2. Put the installer in the parent folder where you want Mix Studio to live. Open the `.bat` on Windows, or run `zsh ~/Downloads/install_MixStudio.command` from Terminal on macOS.
 3. Mix Studio opens in your browser, detects an existing ComfyUI installation, and guides you through the files required by the workflows you choose.
 
-Windows with an NVIDIA GPU is the supported path. The lowest guided route is a 4 GB offloaded edit workflow; 16 GB VRAM is the practical image recommendation and 24 GB is recommended for larger video workflows.
+Windows with an NVIDIA GPU supports the full curated workflow set. Apple Silicon macOS is supported through a source-based ComfyUI environment: setup detects Metal and unified memory, starts ComfyUI with MPS-safe flags, selects the official BF16 LTX 2.3 checkpoint, and disables the FP8-only 10Eros, Wan 2.2, and SCAIL 2 routes. The lowest NVIDIA guided route is a 4 GB offloaded edit workflow; 16 GB VRAM is the practical image recommendation and 24 GB is recommended for larger video workflows.
 
 For manual Git setup, detailed VRAM guidance, shared-model discovery, phone access, troubleshooting, and uninstall behavior, see **[Installation and operations](docs/installation-and-operations.md)**. Do not use GitHub's **Download ZIP** if you want in-app updates.
 

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -584,7 +584,7 @@
               <svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>
               Download for Windows
             </a>
-            <span class="platform-coming"><svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>macOS support coming soon</span>
+            <a class="download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>Download for macOS</a>
           </div>
         </div>
         <div class="hero-visual" aria-label="Mix Studio Create Image interface">
@@ -613,7 +613,7 @@
       <section class="mobile-story" id="mobile-first">
         <div class="mobile-story-copy"><p class="section-kicker">A different local AI workflow</p><h2>The computer does the work. Your phone runs the studio.</h2><p>Most local tools chain you to a desk. Mix Studio lets your PC handle the heavy lifting while giving you full creative control from anywhere.</p></div>
         <div class="control-flow" aria-label="Desktop to phone connection flow">
-          <div class="flow-node"><div class="flow-media flow-desktop"><img src="./mix-studio-create.webp" alt="Mix Studio running on a Windows desktop" loading="lazy" decoding="async" /></div><div class="flow-copy"><strong>GPU power stays home</strong><span>ComfyUI, models, storage, and every generation remain on the Windows machine.</span></div></div>
+          <div class="flow-node"><div class="flow-media flow-desktop"><img src="./mix-studio-create.webp" alt="Mix Studio running on a desktop computer" loading="lazy" decoding="async" /></div><div class="flow-copy"><strong>GPU power stays home</strong><span>ComfyUI, models, storage, and every generation remain on the generation computer.</span></div></div>
           <div class="flow-node"><div class="flow-media flow-link" aria-hidden="true"><div class="flow-device desktop"><img src="./mix-studio-create.webp" alt="" loading="lazy" decoding="async" /></div><i class="flow-signal"></i><div class="flow-device phone"><img src="./mix-studio-mobile.png" alt="" loading="lazy" decoding="async" /></div></div><div class="flow-copy"><strong>Your studio stays within reach</strong><span><a href="https://tailscale.com/download">Tailscale</a> connects the same studio without moving the workload.</span></div></div>
           <div class="flow-node"><div class="flow-media flow-phone"><img src="./mix-studio-mobile.png" alt="Mix Studio's touch-first interface on a phone" loading="lazy" /></div><div class="flow-copy"><strong>Create anywhere</strong><span>Prompt, queue, review, and reuse work from the same responsive UI on desktop or phone.</span></div></div>
         </div>
@@ -623,10 +623,10 @@
         <div class="quick-copy">
           <p class="section-kicker">Quick start</p>
           <h2>Open the app. Finish setup in one place.</h2>
-          <a class="download quick-download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a>
+          <div class="actions"><a class="download quick-download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Windows</a><a class="download quick-download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>macOS</a></div>
         </div>
         <div class="step-list">
-          <article class="guide-step"><div><h3>Run <code>install_MixStudio.bat</code></h3><p>Mix Studio installs into a <code>Mix Studio</code> folder beside the installer, starts, and opens setup automatically when generation is not configured.</p></div></article>
+          <article class="guide-step"><div><h3>Run the installer</h3><p>On Windows, open <code>install_MixStudio.bat</code>. On macOS, run <code>zsh ~/Downloads/install_MixStudio.command</code> in Terminal. Mix Studio installs beside the installer and opens setup automatically.</p></div></article>
           <article class="guide-step"><div><h3>Connect ComfyUI</h3><p>Start a detected installation, install ComfyUI Desktop, or choose a live endpoint. Then use Quick setup, install only that workflow, or open the full guide.</p></div></article>
           <article class="guide-step"><div><h3>Carry it to your phone</h3><p>Add an Owner PIN, then use the Phone access card to install <a href="https://tailscale.com/download">Tailscale</a> and copy or share the private URL.</p></div></article>
         </div>
@@ -688,7 +688,7 @@
       <section class="download-band" aria-label="Download Mix Studio">
         <div class="download-band-actions">
           <a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a>
-          <span class="platform-coming"><svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>macOS download coming soon</span>
+          <a class="download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>Download for macOS</a>
         </div>
         <p class="download-band-tagline">Free &amp; Open Source</p>
       </section>
@@ -726,10 +726,11 @@
           <dl class="faq-list">
             <div class="faq-item"><dt>Is Mix Studio free?</dt><dd>Yes. Mix Studio is free to download. Model licenses still apply.</dd></div>
             <div class="faq-item"><dt>Can I use my ComfyUI install?</dt><dd>Yes. Auto-detect it or choose its folder manually.</dd></div>
+            <div class="faq-item"><dt>What works on Apple Silicon?</dt><dd>Mix Studio supports a source-based ComfyUI environment on macOS, native folder selection, Metal-aware setup, Krea image workflows, and official BF16 LTX 2.3. The FP8-only 10Eros, Wan 2.2, and SCAIL 2 routes are disabled on Metal.</dd></div>
             <div class="faq-item"><dt>Can I reuse downloaded models?</dt><dd>Yes. Registered and manually selected model folders are supported.</dd></div>
             <div class="faq-item"><dt>Can I use a 4 GB GPU?</dt><dd>Yes. Flux 2 Klein 4B FP8 is the 4 GB entry route when current ComfyUI can offload the model and encoder. It will be slower, Krea 2 still starts at 8 GB, and larger workflows may need stronger offloading or quantized weights.</dd></div>
             <div class="faq-item"><dt>Can I generate video with 8 GB of VRAM?</dt><dd>You can try. Mix Studio treats 8 GB as an experimental video offload tier and keeps the install available without a system RAM requirement. Begin with short, smaller videos. The curated graphs recommend 24 GB VRAM, so very long runs or out-of-memory failures remain possible.</dd></div>
-            <div class="faq-item"><dt>What devices can I use?</dt><dd>Run it on Windows, then create from desktop, tablet, or phone.</dd></div>
+            <div class="faq-item"><dt>What devices can I use?</dt><dd>Run it on Windows or Apple Silicon macOS, then create from desktop, tablet, or phone. Metal supports a smaller workflow set than NVIDIA.</dd></div>
             <div class="faq-item"><dt>Does it work away from home?</dt><dd>Yes. Tailscale keeps your studio privately within reach.</dd></div>
             <div class="faq-item"><dt>Does my work stay local?</dt><dd>Yes. Generations and your gallery remain on your machine.</dd></div>
           </dl>
@@ -738,7 +739,7 @@
 
       <section class="closing">
         <div class="closing-copy"><p class="section-kicker">Desktop power, mobile freedom</p><h2>Your GPU stays home.<br />Your studio comes with you.</h2></div>
-        <div class="closing-actions"><a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a><span class="platform-coming"><svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>macOS support coming soon</span></div>
+        <div class="closing-actions"><a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a><a class="download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>Download for macOS</a></div>
       </section>
     </main>
 

--- a/docs/installation-and-operations.md
+++ b/docs/installation-and-operations.md
@@ -43,6 +43,17 @@ Do not use GitHub's **Download ZIP** if you want in-app updates. The updater req
 
 The bootstrap writes ignored, machine-specific configuration to `install.json`. Generation setup merges the ComfyUI URL into `data/settings.json`. It does not reset `data/db.json`, profiles, gallery media, folders, prompts, or presets.
 
+### Apple Silicon field compatibility (experimental)
+
+The packaged installer remains Windows-only, but a manual Node.js 22 checkout can connect to a ComfyUI instance running on Apple Silicon. Mix Studio reads the connected ComfyUI device backend and applies an MPS-specific capability profile:
+
+- LTX 2.3 and LTX Edit use the official `ltx-2.3-22b-dev.safetensors` BF16 checkpoint. Generation setup selects it in place of the curated FP8 checkpoint.
+- 10Eros, Wan 2.2, and SCAIL 2 stay visible but unavailable because their curated FP8 routes are not compatible with Apple Metal.
+- Large two-stage LTX refine requests are rejected before queueing with a safe duration suggestion. Start with short clips and increase duration gradually.
+- Face ID remains installable without the optional BFS audio-guide dependency; an unavailable `librosa` import no longer prevents the identity-overlap node from loading.
+
+For the current ComfyUI MPS route, launch with `--fp32-vae --use-split-cross-attention`. On systems where Metal falls back for an unsupported operation, `PYTORCH_ENABLE_MPS_FALLBACK=1` can provide a slower CPU fallback. Unified memory is shared with macOS and other applications, so close memory-heavy applications before larger LTX runs.
+
 ## Hardware and VRAM
 
 Mix Studio does not enforce a VRAM cutoff. Its ratings describe guided routes for the curated defaults, not guarantees that every resolution or duration will fit.

--- a/docs/installation-and-operations.md
+++ b/docs/installation-and-operations.md
@@ -4,9 +4,9 @@ This guide contains the setup, hardware, networking, update, and maintenance det
 
 ## Supported installation
 
-Mix Studio's supported path is a Windows PC with an NVIDIA GPU and an existing or newly installed ComfyUI environment. The application is distributed as a portable Git checkout rather than a packaged executable. This keeps the installation transparent and lets the owner-only updater fast-forward the checkout without touching user data.
+Mix Studio supports Windows with NVIDIA for the complete curated workflow set and Apple Silicon macOS for the Metal-compatible workflow set. Both use a portable Git checkout rather than a packaged executable. This keeps the installation transparent and lets the owner-only updater fast-forward the checkout without touching user data.
 
-### One-file setup
+### Windows one-file setup
 
 1. Open the [Mix Studio download page](https://blackmixture.github.io/Mix-Studio/) and save `install_MixStudio.bat`.
 2. Put the installer in the parent folder where you want Mix Studio installed. For example, `D:\AI\install_MixStudio.bat` creates `D:\AI\Mix Studio`.
@@ -43,16 +43,21 @@ Do not use GitHub's **Download ZIP** if you want in-app updates. The updater req
 
 The bootstrap writes ignored, machine-specific configuration to `install.json`. Generation setup merges the ComfyUI URL into `data/settings.json`. It does not reset `data/db.json`, profiles, gallery media, folders, prompts, or presets.
 
-### Apple Silicon field compatibility (experimental)
+### Apple Silicon macOS setup
 
-The packaged installer remains Windows-only, but a manual Node.js 22 checkout can connect to a ComfyUI instance running on Apple Silicon. Mix Studio reads the connected ComfyUI device backend and applies an MPS-specific capability profile:
+1. Install Git, Node.js 22 or newer, and a source-based ComfyUI environment with its Python virtual environment at `ComfyUI/.venv` or `ComfyUI/venv`.
+2. Download `install_MixStudio.command` from the [Mix Studio download page](https://blackmixture.github.io/Mix-Studio/).
+3. In Terminal, run `zsh ~/Downloads/install_MixStudio.command`. If the file was saved elsewhere, use its actual path. The script verifies Git and Node, clones the official checkout into a `Mix Studio` folder beside the installer, prepares the local configuration, starts the restart-aware server launcher, and opens the app.
+4. In Generation setup, use the detected ComfyUI source folder or **Browse computer** to select the folder containing `main.py`. Mix Studio recognizes `.venv/bin/python` and `venv/bin/python`, uses POSIX model paths, and can start or safely restart that local process.
+
+Mix Studio reads the connected ComfyUI device backend and applies an MPS-specific capability profile:
 
 - LTX 2.3 and LTX Edit use the official `ltx-2.3-22b-dev.safetensors` BF16 checkpoint. Generation setup selects it in place of the curated FP8 checkpoint.
 - 10Eros, Wan 2.2, and SCAIL 2 stay visible but unavailable because their curated FP8 routes are not compatible with Apple Metal.
 - Large two-stage LTX refine requests are rejected before queueing with a safe duration suggestion. Start with short clips and increase duration gradually.
 - Face ID remains installable without the optional BFS audio-guide dependency; an unavailable `librosa` import no longer prevents the identity-overlap node from loading.
 
-For the current ComfyUI MPS route, launch with `--fp32-vae --use-split-cross-attention`. On systems where Metal falls back for an unsupported operation, `PYTORCH_ENABLE_MPS_FALLBACK=1` can provide a slower CPU fallback. Unified memory is shared with macOS and other applications, so close memory-heavy applications before larger LTX runs.
+Mix Studio launches the configured source environment with `--listen 127.0.0.1 --fp32-vae --use-split-cross-attention` and `PYTORCH_ENABLE_MPS_FALLBACK=1`. It does not set PyTorch's high-watermark ratio to zero because removing that guard can let a generation consume memory needed by macOS. Unified memory is shared with macOS and other applications, so close memory-heavy applications before larger LTX runs.
 
 ## Hardware and VRAM
 
@@ -98,7 +103,7 @@ Some Hugging Face files require accepting a license before their download URL wo
 
 If the official Hugging Face host is unavailable on the current network, enter a trusted Hugging Face-compatible HTTPS base URL under **Settings → General → Hugging Face download endpoint**, or set `HF_ENDPOINT` before launching Mix Studio. The endpoint rewrites only reviewed `huggingface.co` model sources. Mix Studio never sends the configured Hugging Face token to a custom endpoint. Clear the field to return to the official host.
 
-The card exposes **Restart ComfyUI** for a configured Windows ComfyUI folder, but it refuses while either queue is active.
+The card exposes **Restart ComfyUI** for a configured local Windows or macOS source installation, but it refuses while either queue is active. On macOS it verifies that the listener command belongs to the configured `main.py`, sends `SIGTERM`, waits for the port to close, and only then starts the configured environment again.
 
 ## Phone and private remote access
 
@@ -111,7 +116,7 @@ Use **Copy** or **Share** to send the selected address to a phone. Add a PIN to 
 
 For private access away from home, install [Tailscale](https://tailscale.com/download) on both devices and sign them into the same tailnet. Refresh the Phone access card, then copy or share its Tailscale URL. The desktop continues to host ComfyUI, models, and media; the phone remains the control surface.
 
-If the phone cannot connect over the local network, allow Node through Windows Defender Firewall for private networks. Set a different application port with the `PORT` environment variable when required.
+If the phone cannot connect over the local network, allow Node through Windows Defender Firewall or macOS network security controls for private networks. Set a different application port with the `PORT` environment variable when required.
 
 ## Analytics and privacy
 
@@ -148,7 +153,7 @@ Every user-facing release uses the semantic version in `release.json` and a matc
 6. Tag that commit with the matching annotated Git tag and push the tag.
 7. Publish a GitHub Release for that tag with the changelog notes. This final step enables the public Updates inbox notification.
 
-Repository quality checks run on Node 22 for Linux and Windows. A release tag fails validation when it does not match `release.json`, and the download page cannot deploy until the same checks pass.
+Repository quality checks run on Node 22 for Linux, Windows, and macOS. A release tag fails validation when it does not match `release.json`, and the download page cannot deploy until the same checks pass.
 
 ## Restarting, uninstalling, and data safety
 

--- a/docs/portable-install.md
+++ b/docs/portable-install.md
@@ -1,10 +1,10 @@
 # Portable installation and updates
 
-Mix Studio uses a portable Git checkout on Windows. The application, installer, and updater remain readable and editable; profiles and generated media stay in the ignored `data/` directory.
+Mix Studio uses a portable Git checkout on Windows and macOS. The application, installer, and updater remain readable and editable; profiles and generated media stay in the ignored `data/` directory.
 
 The bootstrap is intentionally small. It gets the Mix Studio web app running first, then leaves ComfyUI, models, and custom-node setup inside the app. On an unconfigured installation, the centered setup panel opens automatically. It can start a detected portable or Desktop environment, launch the signed official ComfyUI Desktop installer, discover a live endpoint, and install the curated groups used by Mix Studio's workflow-tested defaults from `installer/feature-manifest.json`.
 
-## New machine
+## New Windows machine
 
 1. Open `https://blackmixture.github.io/Mix-Studio/` on Windows and download `install_MixStudio.bat` into the parent folder where you want Mix Studio installed.
 2. Run the downloaded file. It installs Git through `winget` when necessary and clones the official repository into a `Mix Studio` folder beside the installer. For example, running `D:\AI\install_MixStudio.bat` installs the app at `D:\AI\Mix Studio`.
@@ -31,13 +31,23 @@ Klein, Qwen, Wan, and SCAIL graphs switch to `UnetLoaderGGUF` when their configu
 
 1. Add a PIN to the Owner profile before sharing the studio with another device.
 2. Open the **Phone access card** on the setup Finish step. It lists reachable same-Wi-Fi and Tailscale addresses without requiring the terminal.
-3. For access away from home, use the card's links to install [Tailscale](https://tailscale.com/download) on the Windows generation machine and the phone, then sign both devices into the same tailnet.
+3. For access away from home, use the card's links to install [Tailscale](https://tailscale.com/download) on the generation computer and the phone, then sign both devices into the same tailnet.
 4. Refresh the card, select the private Tailscale address, and use **Copy or share** to send it to the phone.
 5. Open the address on the phone, then add it to the home screen for app-like access.
 
-ComfyUI, model files, galleries, and generation work remain on the Windows machine. The phone sends requests and displays the Mix Studio interface over the private Tailscale connection; public port forwarding is not required.
+ComfyUI, model files, galleries, and generation work remain on the generation computer. The phone sends requests and displays the Mix Studio interface over the private Tailscale connection; public port forwarding is not required.
 
 For a manual installation, install Git for Windows and run `git clone https://github.com/BlackMixture/Mix-Studio.git`, then launch `install_MixStudio.bat` from that checkout.
+
+## New Apple Silicon Mac
+
+1. Install Git, Node.js 22 or newer, and source-based ComfyUI with a `.venv` or `venv` Python environment.
+2. Download `install_MixStudio.command` from the public download page.
+3. Run `zsh ~/Downloads/install_MixStudio.command` in Terminal. The script clones the official repository into `Mix Studio` beside the installer, writes the same portable metadata as Windows, starts `start.command`, and opens the local app.
+4. In Generation setup, select the ComfyUI folder containing `main.py`. Browse uses the native macOS folder picker, and model paths use POSIX separators.
+5. Start ComfyUI from setup. Mix Studio applies `--fp32-vae`, split cross-attention, and the safe MPS fallback environment automatically.
+
+Apple Metal uses the compatible workflow tier. Setup selects official BF16 LTX 2.3 weights and disables the curated FP8-only 10Eros, Wan 2.2, and SCAIL 2 engines. Large LTX refine requests receive an up-front memory warning with a safer duration instead of failing late during stage two.
 
 The installer is intentionally idempotent. Rerunning it preserves the existing `data/` location and ComfyUI connection, refreshes the minimal bootstrap metadata atomically, starts the app, and opens the browser. Generation setup is always available later from **Advanced Settings → General**, and the Phone access card can be reopened from its Finish step.
 
@@ -67,7 +77,7 @@ The optional local models path additionally lets Mix Studio discover LoRA metada
 
 After sign-in, Mix Studio checks the official `BlackMixture/Mix-Studio` GitHub Releases channel for a newer stable semantic version. The server caches successful checks for one hour, and an open browser checks again every six hours. Release notes appear in the Updates inbox; optional browser alerts work while Mix Studio is open. No GitHub credential is shipped with the app, so only maintainers of the official repository can publish notifications.
 
-Each release uses the semantic version and date in `release.json` plus a matching `v<version>` Git tag. GitHub Actions checks server and browser syntax and runs the complete Node test suite on Node 22 for both Linux and Windows. A mismatched release tag fails validation, and the download page deploy waits for the same checks.
+Each release uses the semantic version and date in `release.json` plus a matching `v<version>` Git tag. GitHub Actions checks server and browser syntax and runs the complete Node test suite on Node 22 for Linux, Windows, and macOS. A mismatched release tag fails validation, and the download page deploy waits for the same checks.
 
 The owner-only **Update app** action runs the equivalent of:
 
@@ -77,6 +87,6 @@ git pull --ff-only origin <current-branch>
 
 It refuses to update a detached HEAD or a checkout with modified tracked code. Because `data/` and `install.json` are ignored, updating code does not overwrite the local database, settings, uploads, generations, or ComfyUI paths.
 
-The owner-only **Restart app** action uses the restart-aware `start.bat` launcher. It refuses while either the Mix Studio queue or the connected ComfyUI queue is active.
+The owner-only **Restart app** action uses the restart-aware `start.bat` or `start.command` launcher. It refuses while either the Mix Studio queue or the connected ComfyUI queue is active.
 
 A ZIP archive is runnable after setup, but it has no Git metadata and therefore cannot use the in-app updater. A clone is the supported installation method.

--- a/install_MixStudio.command
+++ b/install_MixStudio.command
@@ -1,0 +1,44 @@
+#!/bin/zsh
+
+set -u
+
+REPOSITORY_URL="https://github.com/BlackMixture/Mix-Studio.git"
+SCRIPT_DIR="${0:A:h}"
+
+fail() {
+  print -u2 ""
+  print -u2 "Mix Studio setup stopped: $1"
+  print -u2 ""
+  read -r "?Press Return to close. "
+  exit 1
+}
+
+GIT_EXE="${MIX_STUDIO_GIT:-$(command -v git 2>/dev/null || true)}"
+[[ -n "$GIT_EXE" ]] || fail "Git is required. Run 'xcode-select --install', finish the Apple installer, then try again."
+
+NODE_EXE="${MIX_STUDIO_NODE:-$(command -v node 2>/dev/null || true)}"
+[[ -n "$NODE_EXE" && -x "$NODE_EXE" ]] || fail "Node.js 22 or newer is required. Install the current LTS from https://nodejs.org/, then try again."
+NODE_MAJOR="$($NODE_EXE -p "process.versions.node.split('.')[0]" 2>/dev/null || true)"
+[[ "$NODE_MAJOR" =~ '^[0-9]+$' && "$NODE_MAJOR" -ge 22 ]] || fail "Mix Studio requires Node.js 22 or newer. Install the current LTS from https://nodejs.org/."
+
+if [[ -f "$SCRIPT_DIR/server.js" && -f "$SCRIPT_DIR/installer/bootstrap.js" ]]; then
+  MIX_STUDIO_HOME="$SCRIPT_DIR"
+else
+  MIX_STUDIO_HOME="$SCRIPT_DIR/Mix Studio"
+  if [[ -e "$MIX_STUDIO_HOME" ]]; then
+    [[ -d "$MIX_STUDIO_HOME/.git" && -f "$MIX_STUDIO_HOME/server.js" ]] || fail "The target '$MIX_STUDIO_HOME' already exists but is not a Mix Studio Git checkout."
+    ORIGIN="$($GIT_EXE -C "$MIX_STUDIO_HOME" remote get-url origin 2>/dev/null || true)"
+    NORMALIZED_ORIGIN="${ORIGIN%.git}"
+    [[ "${NORMALIZED_ORIGIN:l}" == "https://github.com/blackmixture/mix-studio" || "${NORMALIZED_ORIGIN:l}" == "git@github.com:blackmixture/mix-studio" ]] || fail "The existing checkout does not point to the official Mix Studio repository."
+  else
+    print "Downloading Mix Studio…"
+    "$GIT_EXE" clone --depth 1 --branch main --single-branch "$REPOSITORY_URL" "$MIX_STUDIO_HOME" || fail "Git could not download Mix Studio."
+  fi
+fi
+
+export MIX_STUDIO_GIT="$GIT_EXE"
+export MIX_STUDIO_NODE="$NODE_EXE"
+"$NODE_EXE" "$MIX_STUDIO_HOME/installer/bootstrap.js" || fail "The local Mix Studio configuration could not be prepared."
+
+print "Opening Mix Studio…"
+exec /bin/zsh "$MIX_STUDIO_HOME/start.command"

--- a/installer/bootstrap.js
+++ b/installer/bootstrap.js
@@ -25,43 +25,56 @@ function existingObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
-function desktopComfyPath(env = process.env, fsImpl = fs, pathImpl = path) {
-  const appData = String(env.APPDATA || '').trim();
-  if (!appData) return '';
-  const registryFile = pathImpl.join(appData, 'Comfy Desktop', 'installations.json');
-  try {
-    const records = JSON.parse(fsImpl.readFileSync(registryFile, 'utf8'));
-    if (Array.isArray(records)) {
-      const sorted = records
-        .filter((record) => {
-          if (!record || typeof record !== 'object' || record.sourceId === 'cloud') return false;
-          const status = String(record.status || '').trim().toLowerCase();
-          return !status || status === 'installed';
-        })
-        .sort((left, right) => String(right.lastLaunchedAt || right.createdAt || '')
-          .localeCompare(String(left.lastLaunchedAt || left.createdAt || '')));
-      for (const record of sorted) {
-        const installPath = String(record.installPath || '').trim();
-        const adoptedBase = String(record.adoptedBaseDir || '').trim();
-        const base = adoptedBase || (installPath ? pathImpl.join(installPath, 'ComfyUI') : '');
-        const python = String(record.adoptedPythonPath || '').trim()
-          || (base ? pathImpl.join(base, '.venv', 'Scripts', 'python.exe') : '');
-        const main = base ? pathImpl.join(base, 'main.py') : '';
-        if (base && python && fsImpl.existsSync(main) && fsImpl.existsSync(python)) return base;
-      }
-    }
-  } catch { /* current Comfy Desktop has not registered an installation */ }
-  const config = readJson(pathImpl.join(appData, 'ComfyUI', 'config.json'), fsImpl);
-  const base = String(config.basePath || config.base_path || '').trim();
-  if (!base || !fsImpl.existsSync(base)) return '';
+function runnableComfyPath(base, fsImpl = fs, pathImpl = path) {
+  if (!base || !fsImpl.existsSync(pathImpl.join(base, 'main.py'))) return '';
+  const parent = pathImpl.dirname(base);
   const pythonCandidates = [
     pathImpl.join(base, '.venv', 'Scripts', 'python.exe'),
     pathImpl.join(base, 'venv', 'Scripts', 'python.exe'),
-    pathImpl.join(pathImpl.dirname(base), 'python_embeded', 'python.exe'),
+    pathImpl.join(parent, 'python_embeded', 'python.exe'),
     pathImpl.join(base, 'python_embeded', 'python.exe'),
+    pathImpl.join(base, '.venv', 'bin', 'python'),
+    pathImpl.join(base, 'venv', 'bin', 'python'),
   ];
-  return fsImpl.existsSync(pathImpl.join(base, 'main.py'))
-    && pythonCandidates.some((candidate) => fsImpl.existsSync(candidate)) ? base : '';
+  return pythonCandidates.some((candidate) => fsImpl.existsSync(candidate)) ? base : '';
+}
+
+function desktopComfyPath(env = process.env, fsImpl = fs, pathImpl = path) {
+  const appData = String(env.APPDATA || '').trim();
+  if (appData) {
+    const registryFile = pathImpl.join(appData, 'Comfy Desktop', 'installations.json');
+    try {
+      const records = JSON.parse(fsImpl.readFileSync(registryFile, 'utf8'));
+      if (Array.isArray(records)) {
+        const sorted = records
+          .filter((record) => {
+            if (!record || typeof record !== 'object' || record.sourceId === 'cloud') return false;
+            const status = String(record.status || '').trim().toLowerCase();
+            return !status || status === 'installed';
+          })
+          .sort((left, right) => String(right.lastLaunchedAt || right.createdAt || '')
+            .localeCompare(String(left.lastLaunchedAt || left.createdAt || '')));
+        for (const record of sorted) {
+          const installPath = String(record.installPath || '').trim();
+          const adoptedBase = String(record.adoptedBaseDir || '').trim();
+          const base = adoptedBase || (installPath ? pathImpl.join(installPath, 'ComfyUI') : '');
+          const registeredPython = String(record.adoptedPythonPath || '').trim();
+          if (registeredPython && fsImpl.existsSync(pathImpl.join(base, 'main.py')) && fsImpl.existsSync(registeredPython)) return base;
+          if (runnableComfyPath(base, fsImpl, pathImpl)) return base;
+        }
+      }
+    } catch { /* current Comfy Desktop has not registered an installation */ }
+    const config = readJson(pathImpl.join(appData, 'ComfyUI', 'config.json'), fsImpl);
+    const configured = String(config.basePath || config.base_path || '').trim();
+    if (runnableComfyPath(configured, fsImpl, pathImpl)) return configured;
+  }
+  const home = String(env.HOME || env.USERPROFILE || '').trim();
+  const candidates = [
+    String(env.COMFYUI_PATH || '').trim(),
+    home ? pathImpl.join(home, 'ComfyUI') : '',
+    home ? pathImpl.join(home, 'Documents', 'ComfyUI') : '',
+  ];
+  return candidates.find((candidate) => runnableComfyPath(candidate, fsImpl, pathImpl)) || '';
 }
 
 function portableBootstrapConfig(root, options = {}) {
@@ -185,6 +198,7 @@ module.exports = {
   desktopComfyPath,
   portableBootstrapConfig,
   readJson,
+  runnableComfyPath,
   run,
   writeJsonAtomic,
 };

--- a/installer/feature-manifest.json
+++ b/installer/feature-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "product": "Mix Studio",
-  "target": "windows-nvidia",
-  "notes": "The in-app Generation setup guide detects NVIDIA VRAM, recommends curated model families that suit the machine, and reuses existing files. Users may override recommendations after reviewing difficulty warnings.",
+  "target": "desktop-generation",
+  "notes": "The in-app Generation setup guide detects the connected generation device, selects compatible model variants where available, and reuses existing files. Users may override recommendations after reviewing difficulty warnings.",
   "features": [
     {
       "id": "core.image",
@@ -71,7 +71,7 @@
       "id": "video.ltx",
       "label": "LTX 2.3 Video + Face ID",
       "default": false,
-      "variant": "LTX 2.3 22B FP8; 8 GB is an experimental tier with aggressive offload",
+      "variant": "LTX 2.3 22B FP8 on NVIDIA or official BF16 on Apple Silicon; 8 GB is an experimental tier with aggressive offload",
       "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended" },
       "models": ["ltx-2.3", "ltx-distilled", "gemma-3", "ltx-spatial-upscaler", "ltx-face-id", "ltx-face-id-distilled"],
       "nodes": ["VideoHelperSuite", "LTXV", "BFS Nodes", "KJNodes"]
@@ -80,7 +80,7 @@
       "id": "video.ltxEdit",
       "label": "LTX Edit Anything",
       "default": false,
-      "variant": "LTX 2.3 22B FP8 adapter; 8 GB is an experimental tier with aggressive offload",
+      "variant": "LTX 2.3 22B adapter using FP8 on NVIDIA or official BF16 on Apple Silicon; 8 GB is an experimental tier with aggressive offload",
       "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended" },
       "dependsOn": ["video.ltx"],
       "models": ["ltx-edit-anything"],
@@ -91,7 +91,7 @@
       "label": "10Eros DMD",
       "default": false,
       "variant": "10Eros FP8 mixed; 8 GB is an experimental tier with aggressive offload",
-      "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended" },
+      "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended", "unsupportedVendors": ["apple"], "unsupportedReason": "10Eros currently requires FP8 checkpoint and text-encoder operations that Apple Metal cannot execute." },
       "models": ["10eros", "ltx-dmd", "gemma-3"],
       "nodes": ["EchoDMDSampler", "10S-Comfy-nodes", "KJNodes"]
     },
@@ -100,7 +100,7 @@
       "label": "Wan 2.2 Video",
       "default": false,
       "variant": "Wan 2.2 14B FP8; 8 GB is an experimental offload tier and configured GGUF pairs use the GGUF loader",
-      "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended" },
+      "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended", "unsupportedVendors": ["apple"], "unsupportedReason": "Wan 2.2 currently uses curated FP8 model and text-encoder files that Apple Metal cannot execute." },
       "models": ["wan2.2-high", "wan2.2-low", "umt5-xxl", "wan-vae", "wan-lightx2v"],
       "nodes": ["WanImageToVideo", "VideoHelperSuite", "ComfyUI-GGUF"]
     },
@@ -109,7 +109,7 @@
       "label": "SCAIL 2 Motion Transfer",
       "default": false,
       "variant": "SCAIL 2 14B FP8; 8 GB is an experimental offload tier and configured GGUF files use the GGUF loader",
-      "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended" },
+      "hardware": { "minimumVramGb": 8, "recommendedVramGb": 24, "autoSelect": "recommended", "unsupportedVendors": ["apple"], "unsupportedReason": "SCAIL 2 currently uses a curated FP8 Wan model that Apple Metal cannot execute." },
       "dependsOn": ["video.wan"],
       "models": ["scail2", "sam3.1", "clip-vision-h", "pusa"],
       "nodes": ["WanSCAILToVideo", "SAM3_VideoTrack", "comfyui-scail2-infinity", "ComfyUI-GGUF"]

--- a/lib/app-update.js
+++ b/lib/app-update.js
@@ -90,6 +90,7 @@ function restartRequiredForFiles(files) {
   return (files || []).some((file) => (
     file === 'server.js' ||
     file === 'start.bat' ||
+    file === 'start.command' ||
     file === 'package.json' ||
     file === 'package-lock.json' ||
     file.startsWith('lib/')

--- a/lib/comfy-restart.js
+++ b/lib/comfy-restart.js
@@ -78,6 +78,32 @@ function findPortableRunScript(basePath, options = {}) {
   return '';
 }
 
+function pythonLaunchArgs(status, platform = process.platform) {
+  const args = [status.mainPy];
+  if (platform === 'darwin') args.push('--listen', '127.0.0.1');
+  args.push('--port', String(status.port));
+  if (platform === 'darwin') args.push('--fp32-vae', '--use-split-cross-attention');
+  return args;
+}
+
+function pythonLaunchEnvironment(platform = process.platform, env = process.env) {
+  if (platform !== 'darwin') return {};
+  return { PYTORCH_ENABLE_MPS_FALLBACK: String(env.PYTORCH_ENABLE_MPS_FALLBACK || '1') };
+}
+
+function spawnPythonComfy(status, options = {}) {
+  const platform = options.platform || process.platform;
+  const env = options.env || process.env;
+  const child = spawn(status.pythonPath, pythonLaunchArgs(status, platform), {
+    cwd: path.dirname(status.mainPy),
+    detached: true,
+    windowsHide: true,
+    stdio: 'ignore',
+    env: Object.assign({}, process.env, env, pythonLaunchEnvironment(platform, env)),
+  });
+  child.unref();
+}
+
 function startStatus(runtime, options = {}) {
   const existsSync = options.existsSync || fs.existsSync;
   const platform = options.platform || process.platform;
@@ -86,9 +112,9 @@ function startStatus(runtime, options = {}) {
   const partialBase = detectedBase ? '' : findPartialComfyBase(runtime, options);
   const configuredBase = String(runtime.comfy?.path || '').trim();
   const basePath = detectedBase || (configuredBase && existsSync(configuredBase) ? configuredBase : '');
-  const desktopApp = findComfyDesktopApp(options);
-  const desktopRecord = desktopRecordForBase(basePath || partialBase, options);
-  const runScript = desktopRecord ? '' : findPortableRunScript(basePath, options);
+  const desktopApp = platform === 'win32' ? findComfyDesktopApp(options) : '';
+  const desktopRecord = platform === 'win32' ? desktopRecordForBase(basePath || partialBase, options) : null;
+  const runScript = platform === 'win32' && !desktopRecord ? findPortableRunScript(basePath, options) : '';
   const sourceBase = desktopRecord && desktopRecord.installPath
     ? pathApi.join(String(desktopRecord.installPath), 'ComfyUI')
     : basePath;
@@ -104,9 +130,9 @@ function startStatus(runtime, options = {}) {
   else if (runScript) kind = 'portable';
   else if (mainPy && pythonPath) kind = 'python';
   else if (desktopApp) kind = 'desktop';
-  const canStart = platform === 'win32' && !!kind;
+  const canStart = (platform === 'win32' && !!kind) || (platform === 'darwin' && kind === 'python');
   const installationName = String(desktopRecord?.name || desktopRecord?.id || '').trim();
-  return {
+  const status = {
     canStart,
     kind,
     basePath,
@@ -118,12 +144,17 @@ function startStatus(runtime, options = {}) {
     installationName,
     requiresUserAction: kind === 'desktop',
     port: comfyPort(runtime.comfy && runtime.comfy.url),
-    reason: platform !== 'win32'
-      ? 'ComfyUI can be started from the Windows generation computer.'
+    reason: !['win32', 'darwin'].includes(platform)
+      ? 'Start ComfyUI on the generation computer, then use Find running ComfyUI.'
+      : (platform === 'darwin' && kind !== 'python'
+        ? 'Choose a source-based ComfyUI folder with main.py and a .venv Python environment.'
       : (!kind
         ? 'Mix Studio could not find a Comfy Desktop app, portable launch script, or runnable ComfyUI source folder.'
-        : ''),
+        : '')),
   };
+  status.launchArgs = kind === 'python' ? pythonLaunchArgs(status, platform) : [];
+  status.launchEnv = kind === 'python' ? pythonLaunchEnvironment(platform, options.env || process.env) : {};
+  return status;
 }
 
 async function startComfy(runtime, report = () => {}, options = {}) {
@@ -150,8 +181,7 @@ async function startComfy(runtime, report = () => {}, options = {}) {
     const child = spawn('cmd.exe', ['/d', '/s', '/c', status.runScript], { cwd: path.dirname(status.runScript), detached: true, windowsHide: true, stdio: 'ignore' });
     child.unref();
   } else {
-    const child = spawn(status.pythonPath, [status.mainPy, '--port', String(status.port)], { cwd: path.dirname(status.mainPy), detached: true, windowsHide: true, stdio: 'ignore' });
-    child.unref();
+    spawnPythonComfy(status, options);
   }
   report('discovering', 'Waiting for ComfyUI to report its local address…');
   return status;
@@ -170,13 +200,14 @@ function restartStatus(runtime, options = {}) {
   const basePath = detectedBase || (configuredRunnable ? configuredBase : '');
   const configuredUrl = String(runtime.comfy?.url || '').trim();
   const localUrl = !configuredUrl || isLoopbackUrl(configuredUrl);
-  const desktopRecord = desktopRecordForBase(basePath, options);
+  const desktopRecord = platform === 'win32' ? desktopRecordForBase(basePath, options) : null;
   const pythonPath = findComfyPython(basePath, options);
-  const runScript = findPortableRunScript(basePath, options);
+  const runScript = platform === 'win32' ? findPortableRunScript(basePath, options) : '';
   const mainPy = basePath ? path.join(basePath, 'main.py') : '';
-  const canRestart = platform === 'win32' && localUrl && !desktopRecord && !!basePath
+  const supportedPlatform = platform === 'win32' || platform === 'darwin';
+  const canRestart = supportedPlatform && localUrl && !desktopRecord && !!basePath
     && (!!runScript || (!!pythonPath && existsSync(mainPy)));
-  return {
+  const status = {
     canRestart,
     kind: desktopRecord ? 'desktop' : (runScript ? 'portable' : (mainPy && pythonPath ? 'python' : '')),
     basePath,
@@ -184,15 +215,18 @@ function restartStatus(runtime, options = {}) {
     runScript,
     mainPy: existsSync(mainPy) ? mainPy : '',
     port: comfyPort(runtime.comfy && runtime.comfy.url),
-    reason: platform !== 'win32'
-      ? 'ComfyUI restart is available from the Windows desktop that runs generation.'
+    reason: !supportedPlatform
+      ? 'Restart ComfyUI on the generation computer, then press Check again.'
       : (!localUrl
         ? 'Mix Studio will not restart a ComfyUI server configured on another computer.'
         : (desktopRecord
           ? 'Restart this installation from Comfy Desktop so its managed environment and port remain consistent.'
-          : (!basePath ? 'Set the ComfyUI folder in install_MixStudio.bat before restarting from Mix Studio.'
+          : (!basePath ? `Set the ComfyUI folder in ${platform === 'darwin' ? 'Generation setup' : 'install_MixStudio.bat'} before restarting from Mix Studio.`
             : 'Mix Studio could not find run_nvidia_gpu.bat or main.py in the configured ComfyUI folder.'))),
   };
+  status.launchArgs = status.kind === 'python' ? pythonLaunchArgs(status, platform) : [];
+  status.launchEnv = status.kind === 'python' ? pythonLaunchEnvironment(platform, options.env || process.env) : {};
+  return status;
 }
 
 function run(command, args, options = {}) {
@@ -206,6 +240,16 @@ function run(command, args, options = {}) {
 
 async function pidsListeningOn(port, options = {}) {
   const runCommand = options.run || run;
+  const platform = options.platform || process.platform;
+  if (platform === 'darwin') {
+    let out = '';
+    try {
+      out = await runCommand('/usr/sbin/lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t']);
+    } catch (error) {
+      if (Number(error?.code) !== 1) throw error;
+    }
+    return [...new Set(String(out).split(/\s+/).map(Number).filter((pid) => Number.isInteger(pid) && pid > 0))];
+  }
   const out = await runCommand('netstat', ['-ano', '-p', 'tcp']);
   const matches = new Set();
   const expression = new RegExp(`\\s(?:0\\.0\\.0\\.0|127\\.0\\.0\\.1|\\[::\\]|[^\\s:]+):${port}\\s+`, 'i');
@@ -220,6 +264,12 @@ async function pidsListeningOn(port, options = {}) {
 async function processInfoForPid(pid, options = {}) {
   if (typeof options.processInfo === 'function') return options.processInfo(pid);
   const runCommand = options.run || run;
+  const platform = options.platform || process.platform;
+  if (platform === 'darwin') {
+    const output = await runCommand('/bin/ps', ['-p', String(Number(pid)), '-o', 'pid=', '-o', 'command=']);
+    const matched = String(output || '').trim().match(/^(\d+)\s+([\s\S]+)$/);
+    return matched ? { ProcessId: Number(matched[1]), CommandLine: matched[2] } : null;
+  }
   const env = options.env || process.env;
   const systemRoot = String(env.SystemRoot || 'C:\\Windows');
   const powershell = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
@@ -263,7 +313,7 @@ async function restartComfy(runtime, report = () => {}, options = {}) {
   report('stopping', 'Stopping the ComfyUI process…');
   let pids;
   try {
-    pids = await pidsListeningOn(status.port, { run: runCommand });
+    pids = await pidsListeningOn(status.port, { run: runCommand, platform: options.platform });
   } catch (cause) {
     const error = new Error('Mix Studio could not verify which process owns the ComfyUI port. Nothing was stopped.');
     error.code = 'comfy_restart_listener_query_failed';
@@ -280,7 +330,24 @@ async function restartComfy(runtime, report = () => {}, options = {}) {
     }
     verified.push(pid);
   }
-  for (const pid of verified) await runCommand('taskkill', ['/PID', String(pid), '/T', '/F']);
+  const platform = options.platform || process.platform;
+  for (const pid of verified) {
+    if (platform === 'darwin') await runCommand('/bin/kill', ['-TERM', String(pid)]);
+    else await runCommand('taskkill', ['/PID', String(pid), '/T', '/F']);
+  }
+  if (platform === 'darwin' && verified.length) {
+    const wait = options.wait || ((delay) => new Promise((resolve) => setTimeout(resolve, delay)));
+    let remaining = verified;
+    for (let attempt = 0; attempt < 40 && remaining.length; attempt += 1) {
+      await wait(250);
+      remaining = await pidsListeningOn(status.port, { run: runCommand, platform }).catch(() => remaining);
+    }
+    if (remaining.length) {
+      const error = new Error(`ComfyUI did not release port ${status.port} after a safe stop request. Nothing new was started.`);
+      error.code = 'comfy_restart_stop_timeout';
+      throw error;
+    }
+  }
   report('starting', 'Starting ComfyUI…');
   if (options.spawn) {
     options.spawn(status);
@@ -288,8 +355,7 @@ async function restartComfy(runtime, report = () => {}, options = {}) {
     const child = spawn('cmd.exe', ['/d', '/s', '/c', status.runScript], { cwd: status.basePath, detached: true, windowsHide: true, stdio: 'ignore' });
     child.unref();
   } else {
-    const child = spawn(status.pythonPath, [status.mainPy, '--port', String(status.port)], { cwd: status.basePath, detached: true, windowsHide: true, stdio: 'ignore' });
-    child.unref();
+    spawnPythonComfy(status, options);
   }
   report('reconnecting', 'Waiting for ComfyUI to come back online…');
   return status;
@@ -303,6 +369,8 @@ module.exports = {
   isExpectedComfyProcess,
   pidsListeningOn,
   processInfoForPid,
+  pythonLaunchArgs,
+  pythonLaunchEnvironment,
   restartComfy,
   restartStatus,
   startComfy,

--- a/lib/comfy-widget-spec.js
+++ b/lib/comfy-widget-spec.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const SCALAR_WIDGET_TYPES = new Set(['INT', 'FLOAT', 'STRING', 'BOOLEAN', 'COMBO']);
+
+function isWidgetType(value) {
+  const members = String(value || '').split(',').map((member) => member.trim().toUpperCase()).filter(Boolean);
+  return members.length > 0 && members.every((member) => SCALAR_WIDGET_TYPES.has(member));
+}
+
+function isWidgetSpec(spec) {
+  if (!Array.isArray(spec)) return false;
+  const type = spec[0];
+  if (Array.isArray(type)) return true;
+  if (typeof type !== 'string') return false;
+  if (type.startsWith('COMFY_') && type.includes('COMBO')) return true;
+
+  const members = type.split(',').map((value) => value.trim()).filter(Boolean);
+  if (members.length && members.every(isWidgetType)) return true;
+
+  // Newer ComfyUI schemas can retain a connection-compatible union in the
+  // main type while identifying the serialized widget through this hint.
+  return isWidgetType(spec[1]?.widgetType);
+}
+
+module.exports = {
+  SCALAR_WIDGET_TYPES,
+  isWidgetSpec,
+  isWidgetType,
+};

--- a/lib/dependency-installer.js
+++ b/lib/dependency-installer.js
@@ -78,7 +78,11 @@ const NODE_PACKS = Object.freeze({
   ltxvideo: { label: 'LTXVideo', folder: 'ComfyUI-LTXVideo', repo: 'https://github.com/Lightricks/ComfyUI-LTXVideo.git', ref: 'aceeae9635f6d493f2893ba3c411a1c36031788a', compatibilityPatch: 'kornia-pad' },
   rife: { label: 'Frame Interpolation', folder: 'ComfyUI-Frame-Interpolation', repo: 'https://github.com/Fannovel16/ComfyUI-Frame-Interpolation.git', ref: '26545cc2dd95bc3d27f056016300673bdeee78f5' },
   eros: { label: '10S Comfy Nodes', folder: '10S-Comfy-nodes', repo: 'https://github.com/TenStrip/10S-Comfy-nodes.git', ref: '257400c45394efb2fa53a0a8fe3b3e8ac7392548' },
-  bfs: { label: 'BFS Nodes', folder: 'ComfyUI-BFSNodes', repo: 'https://github.com/alisson-anjos/ComfyUI-BFSNodes.git', ref: '7112d6e640941e5f9c6f0402efd592f8bf340a06' },
+  bfs: {
+    label: 'BFS Nodes', folder: 'ComfyUI-BFSNodes', repo: 'https://github.com/alisson-anjos/ComfyUI-BFSNodes.git',
+    ref: '7112d6e640941e5f9c6f0402efd592f8bf340a06', compatibilityPatch: 'bfs-optional-audio',
+    omitRequirementsByPlatform: { darwin: ['librosa'] },
+  },
   scailInfinity: { label: 'SCAIL 2 Infinity', folder: 'comfyui-scail2-infinity', repo: 'https://github.com/collbroGTR/comfyui-scail2-infinity.git', ref: '08dcf0d56979fc2238ce8c7716dad6cb7e9c9a89' },
   regional: {
     label: 'Krea 2 Regional MultiLoRA',
@@ -158,8 +162,8 @@ const MODEL_ASSETS = Object.freeze({
     ['ltxEditLora', 'loras', hf('Alissonerdx/EditAnything', 'edit_anything_v1.1_r256.safetensors')],
   ],
   faceid: [
-    ['ltxFaceIdLora', 'loras', hf('Kijai/LTX-2.3-FaceID', 'Best_FaceID_v1.0_LoRA.safetensors')],
-    ['ltxFaceIdDistilledLora', 'loras', hf('Lightricks/LTX-2.3', 'ltx-2.3-22b-distilled-1.1_lora-dynamic_fro09_avg_rank_111_bf16.safetensors')],
+    ['ltxFaceIdLora', 'loras', hf('Alissonerdx/LTX-Best-Face-ID', 'Best_FaceID_v1.0_LoRA.safetensors')],
+    ['ltxFaceIdDistilledLora', 'loras', hf('Comfy-Org/ltx-2.3', 'split_files/loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors')],
   ],
   wan: [
     ['wanHighUnet', 'diffusion_models', hf('Comfy-Org/Wan_2.2_ComfyUI_Repackaged', 'split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors')],
@@ -183,8 +187,8 @@ const MODEL_ASSETS = Object.freeze({
       undefined,
       [hf('lightx2v/Wan2.1-I2V-14B-720P-StepDistill-CfgDistill-Lightx2v', 'loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors')],
     ],
-    ['scailPusaLora', 'loras', hf('Comfy-Org/SCAIL-2', 'loras/Pusa/Wan21_PusaV1_LoRA_14B_rank512_bf16.safetensors')],
-    ['scailClipVision', 'clip_vision', hf('Comfy-Org/SCAIL-2', 'clip_vision/clip_vision_h.safetensors')],
+    ['scailPusaLora', 'loras', hf('Kijai/WanVideo_comfy', 'Pusa/Wan21_PusaV1_LoRA_14B_rank512_bf16.safetensors')],
+    ['scailClipVision', 'clip_vision', hf('Comfy-Org/Wan_2.1_ComfyUI_repackaged', 'split_files/clip_vision/clip_vision_h.safetensors')],
     ['scailSam', 'checkpoints', hf('Comfy-Org/sam3.1', 'checkpoints/sam3.1_multiplex_fp16.safetensors')],
   ],
 });
@@ -193,6 +197,12 @@ const KLEIN4_LEGACY_BF16_ASSET = Object.freeze([
   'klein4Unet',
   'diffusion_models',
   hf('black-forest-labs/FLUX.2-klein-4B', 'flux-2-klein-4b.safetensors'),
+]);
+
+const LTX_APPLE_BF16_ASSET = Object.freeze([
+  'ltxCkpt',
+  'checkpoints',
+  hf('Lightricks/LTX-2.3', 'ltx-2.3-22b-dev.safetensors'),
 ]);
 
 const KREA2_VARIANT_ASSETS = Object.freeze({
@@ -216,10 +226,16 @@ function dependencyModelPlan(modelGroups, settings = {}, options = {}) {
   else if (requested && groups.includes('krea2Raw')) {
     settingUpdates = { krea2RawUnet: KREA2_VARIANTS[krea2Variant].raw };
   }
+  const appleLtx = String(options.gpuVendor || '').toLowerCase() === 'apple' && groups.includes('ltx');
+  const configuredLtx = normalizeModelName(settings.ltxCkpt);
+  if (appleLtx && (!configuredLtx || configuredLtx === 'ltx-2.3-22b-dev-fp8.safetensors')) {
+    settingUpdates.ltxCkpt = 'ltx-2.3-22b-dev.safetensors';
+  }
   let effectiveSettings = Object.assign({}, settings, settingUpdates);
   const variantAssets = new Map((KREA2_VARIANT_ASSETS[krea2Variant] || []).map((asset) => [asset[0], asset]));
   const assets = [...new Map(groups.flatMap((key) => (MODEL_ASSETS[key] || []).map((asset) => {
     if ((key === 'image' || key === 'krea2Raw') && variantAssets.has(asset[0])) return variantAssets.get(asset[0]);
+    if (key === 'ltx' && asset[0] === 'ltxCkpt' && appleLtx) return LTX_APPLE_BF16_ASSET;
     if (key === 'klein4' && asset[0] === 'klein4Unet'
       && normalizeModelName(effectiveSettings.klein4Unet) === 'flux-2-klein-4b.safetensors') {
       return KLEIN4_LEGACY_BF16_ASSET;
@@ -399,15 +415,41 @@ function filterProtectedRuntimeRequirements(source) {
     .join('\n');
 }
 
+function installedRequirementNames(source) {
+  return new Set(String(source || '').split(/\r?\n/)
+    .map(requirementPackageName)
+    .filter(Boolean));
+}
+
+function filterRequirementsForEnvironment(source, environmentSnapshot = '', options = {}) {
+  const installed = installedRequirementNames(environmentSnapshot);
+  const omitted = new Set((options.omitPackages || []).map((value) => requirementPackageName(value)));
+  const installedOpenCv = [...installed].some((name) => name.startsWith('opencv-'));
+  return String(source || '').split(/\r?\n/)
+    .filter((line) => {
+      const name = requirementPackageName(line);
+      if (!name) return true;
+      if (omitted.has(name)) return false;
+      if (options.repair && PROTECTED_RUNTIME_REQUIREMENTS.has(name)) return false;
+      if (name.startsWith('opencv-') && installedOpenCv) return false;
+      return !(PROTECTED_RUNTIME_REQUIREMENTS.has(name) && installed.has(name));
+    })
+    .join('\n');
+}
+
 function protectedRuntimeConstraints(source) {
   return String(source || '').split(/\r?\n/)
     .filter((line) => PROTECTED_RUNTIME_REQUIREMENTS.has(requirementPackageName(line)))
     .join('\n');
 }
 
-async function safeRepairRequirementsFile(requirements) {
+async function safeNodeRequirementsFile(requirements, options = {}) {
   const source = await fsp.readFile(requirements, 'utf8');
-  const filtered = filterProtectedRuntimeRequirements(source);
+  let environmentSnapshot = '';
+  if (options.environmentSnapshot) {
+    try { environmentSnapshot = await fsp.readFile(options.environmentSnapshot, 'utf8'); } catch { /* snapshot is optional */ }
+  }
+  const filtered = filterRequirementsForEnvironment(source, environmentSnapshot, options);
   if (filtered === source) return { path: requirements, temporary: false };
   const safePath = `${requirements}.mixbox-safe`;
   await fsp.writeFile(safePath, filtered, 'utf8');
@@ -539,6 +581,31 @@ async function patchLtxVideoKornia(nodePath) {
   return true;
 }
 
+async function patchBfsOptionalAudio(nodePath) {
+  const file = path.join(nodePath, '__init__.py');
+  let source;
+  try { source = await fsp.readFile(file, 'utf8'); } catch { return false; }
+  if (source.includes('[BFSNodes] AMV Guide node not loaded')) return false;
+  const imports = [
+    'from .amv_guide_node import NODE_CLASS_MAPPINGS as AMV_NODE_CLASS_MAPPINGS',
+    'from .amv_guide_node import NODE_DISPLAY_NAME_MAPPINGS as AMV_NODE_DISPLAY_NAME_MAPPINGS',
+  ];
+  if (!imports.every((line) => source.includes(line))) return false;
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  const guarded = [
+    'try:',
+    `    ${imports[0]}`,
+    `    ${imports[1]}`,
+    'except Exception as _e:  # noqa',
+    '    print(f"[BFSNodes] AMV Guide node not loaded: {_e!r}")',
+    '    AMV_NODE_CLASS_MAPPINGS, AMV_NODE_DISPLAY_NAME_MAPPINGS = {}, {}',
+  ].join(newline);
+  const patched = source.replace(`${imports[0]}${newline}${imports[1]}`, guarded);
+  if (patched === source) return false;
+  await fsp.writeFile(file, patched, 'utf8');
+  return true;
+}
+
 function uvCandidates(pythonPath) {
   const pythonDir = pythonPath ? path.dirname(pythonPath) : '';
   return [path.join(pythonDir, 'uv.exe'), path.join(pythonDir, 'uv')];
@@ -638,10 +705,18 @@ async function installNodePack(pack, status, report, options = {}) {
   if (pack.compatibilityPatch === 'kornia-pad' && await patchLtxVideoKornia(nodePath)) {
     report('compatibility-patch', `Updated ${pack.label} for kornia 0.8.3 and newer`);
   }
+  if (pack.compatibilityPatch === 'bfs-optional-audio' && await patchBfsOptionalAudio(nodePath)) {
+    report('compatibility-patch', `Made ${pack.label}'s optional audio node safe to skip on this platform`);
+  }
   const requirements = path.join(nodePath, 'requirements.txt');
   if (existsSync(requirements)) {
     const repair = !!options.repair;
-    const safeRequirements = repair ? await safeRepairRequirementsFile(requirements) : { path: requirements, temporary: false };
+    const omitPackages = pack.omitRequirementsByPlatform?.[options.platform || process.platform] || [];
+    const safeRequirements = await safeNodeRequirementsFile(requirements, {
+      repair,
+      environmentSnapshot: options.environmentSnapshot,
+      omitPackages,
+    });
     report('requirements', repair
       ? `Repairing ${pack.label} requirements without changing unrelated packages`
       : `Installing ${pack.label} requirements without upgrading unrelated packages`);
@@ -727,6 +802,13 @@ async function installNodeRequirements(status, requirements, repair, report, opt
     });
   } catch (pipError) {
     if (options.signal?.aborted || pipError?.code === 'dependency_cancelled' || pipError?.name === 'AbortError') throw pipError;
+    if (/(?:WinError 5|Access is denied)[\s\S]*cv2\.pyd/i.test(String(pipError?.message || pipError || ''))) {
+      throw nodePackError(
+        'ComfyUI is currently using its OpenCV runtime. Mix Studio preserved that installed version; stop ComfyUI completely, retry this dependency once, then restart ComfyUI.',
+        'dependency_requirements_locked',
+        { cause: pipError }
+      );
+    }
     const reason = requirementFallbackReason(pipError);
     if (!reason) throw pipError;
     report('requirements-fallback', `Using this ComfyUI environment's uv installer because ${reason}`);
@@ -1411,6 +1493,8 @@ async function installComponents({ runtime, settings, components, report = () =>
     try {
       await installNodePack(pack, status, (phase, message, detail) => report(phase, message, Object.assign({ completed, total, component: id }, detail || {})), Object.assign({}, nodeOptions, {
         constraintFile: runtimeConstraintFile,
+        environmentSnapshot,
+        platform: options.platform || process.platform,
         nodeInspection: preflight.inspections.get(id),
       }));
     } catch (error) {
@@ -1487,6 +1571,7 @@ module.exports = {
   ensureDownloadDiskSpace,
   findExistingModelByBasename,
   filterProtectedRuntimeRequirements,
+  filterRequirementsForEnvironment,
   huggingFaceEndpointUrl,
   huggingFaceAccessUrl,
   ensureUv,
@@ -1494,6 +1579,7 @@ module.exports = {
   installNodeRequirements,
   nodePackHasSignatures,
   patchLtxVideoKornia,
+  patchBfsOptionalAudio,
   protectedRuntimeConstraints,
   installNodePack,
   installComponents,
@@ -1503,6 +1589,7 @@ module.exports = {
   normalizeModelName,
   requirementsArgs,
   requirementFallbackReason,
+  safeNodeRequirementsFile,
   sameRepo,
   snapshotPythonEnvironment,
   validateModelFile,

--- a/lib/folder-picker.js
+++ b/lib/folder-picker.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { execFile } = require('child_process');
+const { browseWindowsFolder } = require('./windows-folder-picker');
+
+function appleScriptString(value) {
+  return `"${String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function macFolderPickerScript(description) {
+  return `POSIX path of (choose folder with prompt ${appleScriptString(description || 'Choose a folder')})`;
+}
+
+function browseMacFolder(kind, options = {}) {
+  const execFileFn = options.execFileFn || execFile;
+  const description = kind === 'models' ? 'Choose the ComfyUI models folder' : 'Choose the ComfyUI folder';
+  return new Promise((resolve, reject) => {
+    execFileFn(options.osascript || '/usr/bin/osascript', ['-e', macFolderPickerScript(description)], {
+      timeout: options.timeoutMs || 10 * 60 * 1000,
+      maxBuffer: 64 * 1024,
+    }, (error, stdout, stderr) => {
+      if (!error) {
+        const selected = String(stdout || '').trim();
+        return resolve(selected.length > 1 ? selected.replace(/\/+$/, '') : selected);
+      }
+      const diagnostic = String(stderr || '').trim() || String(error.message || error);
+      if (/-128\b|user canceled/i.test(diagnostic)) return resolve('');
+      const wrapped = new Error(`macOS could not open the folder picker. Enter the folder path manually, or retry from the Mac running Mix Studio. ${diagnostic}`);
+      wrapped.code = 'folder_picker_failed';
+      wrapped.cause = error;
+      reject(wrapped);
+    });
+  });
+}
+
+function browseGenerationFolder(kind, options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform === 'win32') return browseWindowsFolder(kind, options);
+  if (platform === 'darwin') return browseMacFolder(kind, options);
+  const error = new Error('Folder browsing is not available on this generation computer. Enter the absolute path manually.');
+  error.code = 'folder_picker_unavailable';
+  throw error;
+}
+
+module.exports = {
+  appleScriptString,
+  browseGenerationFolder,
+  browseMacFolder,
+  macFolderPickerScript,
+};

--- a/lib/generation-capabilities.js
+++ b/lib/generation-capabilities.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const APPLE_UNSUPPORTED_ENGINES = Object.freeze({
+  eros: '10Eros currently requires FP8 checkpoint and text-encoder operations that Apple Metal cannot execute.',
+  wan: 'Wan 2.2 currently uses curated FP8 model and text-encoder files that Apple Metal cannot execute.',
+  scail: 'SCAIL 2 currently uses a curated FP8 Wan model that Apple Metal cannot execute.',
+});
+
+const APPLE_UNSUPPORTED_COMPONENTS = Object.freeze({
+  eros: APPLE_UNSUPPORTED_ENGINES.eros,
+  wan: APPLE_UNSUPPORTED_ENGINES.wan,
+  scail: APPLE_UNSUPPORTED_ENGINES.scail,
+  scailinfinity: APPLE_UNSUPPORTED_ENGINES.scail,
+});
+
+const APPLE_LTX_REFINE_TOKEN_LIMIT = 45_000;
+const GENERAL_LTX_REFINE_TOKEN_LIMIT = 200_000;
+
+function appleGenerationProfile(profile = {}) {
+  const vendor = String(profile.gpuVendor || profile.vendor || '').toLowerCase();
+  const backend = String(profile.gpuBackend || profile.backend || '').toLowerCase();
+  return vendor === 'apple' || backend === 'mps';
+}
+
+function fp8Model(value) {
+  return /(?:^|[_.-])fp8(?:[_.-]|$)|float8|e4m3/i.test(String(value || ''));
+}
+
+function videoEngineCapabilities(profile = {}) {
+  const apple = appleGenerationProfile(profile);
+  const result = {};
+  for (const engine of ['ltx', 'ltx-edit', 'eros', 'wan', 'scail']) {
+    const reason = apple ? APPLE_UNSUPPORTED_ENGINES[engine] : '';
+    result[engine] = {
+      supported: !reason,
+      reason,
+      requiresBf16: apple && (engine === 'ltx' || engine === 'ltx-edit'),
+    };
+  }
+  return result;
+}
+
+function configuredVideoEngineCapability(engine, profile = {}, settings = {}) {
+  const base = videoEngineCapabilities(profile)[engine] || { supported: true, reason: '', requiresBf16: false };
+  if (!base.supported) return base;
+  if (base.requiresBf16 && fp8Model(settings.ltxCkpt)) {
+    return {
+      supported: false,
+      requiresBf16: true,
+      reason: 'LTX 2.3 on Apple Silicon needs the official BF16 checkpoint. Open Generation Setup and install the LTX workflow to select it.',
+    };
+  }
+  return base;
+}
+
+function configuredVideoEngineCapabilities(profile = {}, settings = {}) {
+  return Object.fromEntries(['ltx', 'ltx-edit', 'eros', 'wan', 'scail']
+    .map((engine) => [engine, configuredVideoEngineCapability(engine, profile, settings)]));
+}
+
+function dependencyComponentBlock(componentId, profile = {}) {
+  if (!appleGenerationProfile(profile)) return '';
+  return APPLE_UNSUPPORTED_COMPONENTS[componentId] || '';
+}
+
+function ltxRefineTokenCount(width, height, frames) {
+  const spatial = Math.ceil(Math.max(1, Number(width) || 1) / 32)
+    * Math.ceil(Math.max(1, Number(height) || 1) / 32);
+  const temporal = Math.ceil(Math.max(1, Number(frames) || 1) / 8);
+  return spatial * temporal;
+}
+
+function ltxRefinePreflight({ width, height, frames, fps, profile = {} } = {}) {
+  const spatial = Math.ceil(Math.max(1, Number(width) || 1) / 32)
+    * Math.ceil(Math.max(1, Number(height) || 1) / 32);
+  const tokens = ltxRefineTokenCount(width, height, frames);
+  const limit = appleGenerationProfile(profile)
+    ? APPLE_LTX_REFINE_TOKEN_LIMIT
+    : GENERAL_LTX_REFINE_TOKEN_LIMIT;
+  if (tokens <= limit) return { ok: true, tokens, limit };
+
+  const temporalGroups = Math.max(1, Math.floor(limit / spatial));
+  const maxFrames = Math.max(1, (temporalGroups - 1) * 8 + 1);
+  const rate = Math.max(1, Number(fps) || 25);
+  const maxSeconds = Math.max(1, Math.floor(((maxFrames - 1) / rate) * 10) / 10);
+  return {
+    ok: false,
+    tokens,
+    limit,
+    maxFrames,
+    maxSeconds,
+    error: `This refined LTX request is too large for the connected generation device. Use ${maxSeconds} seconds or less at ${width} × ${height}, or lower the output size.`,
+  };
+}
+
+module.exports = {
+  APPLE_LTX_REFINE_TOKEN_LIMIT,
+  APPLE_UNSUPPORTED_COMPONENTS,
+  APPLE_UNSUPPORTED_ENGINES,
+  GENERAL_LTX_REFINE_TOKEN_LIMIT,
+  appleGenerationProfile,
+  configuredVideoEngineCapability,
+  configuredVideoEngineCapabilities,
+  dependencyComponentBlock,
+  fp8Model,
+  ltxRefinePreflight,
+  ltxRefineTokenCount,
+  videoEngineCapabilities,
+};

--- a/lib/hardware-info.js
+++ b/lib/hardware-info.js
@@ -10,6 +10,16 @@ function cleanName(value, fallback = 'Unavailable') {
   return text || fallback;
 }
 
+function gpuVendor(name, backend = '') {
+  const type = String(backend || '').toLowerCase();
+  const text = String(name || '').toLowerCase();
+  if (type === 'mps' || /^apple\b/.test(text)) return 'apple';
+  if (/nvidia|geforce|quadro|\btesla\b/.test(text)) return 'nvidia';
+  if (/\bamd\b|radeon|instinct|\bryzen\b/.test(text)) return 'amd';
+  if (type === 'xpu' || /\bintel\b|\barc\b/.test(text)) return 'intel';
+  return 'unknown';
+}
+
 function parseNvidiaGpuCsv(text) {
   return String(text || '').trim().split(/\r?\n/).filter(Boolean).map((line) => {
     const parts = line.split(',').map((part) => part.trim());
@@ -18,8 +28,31 @@ function parseNvidiaGpuCsv(text) {
       name: cleanName(parts[0]),
       memoryBytes: Number.isFinite(memoryMb) && memoryMb > 0 ? Math.round(memoryMb * 1024 * 1024) : null,
       driver: cleanName(parts[2], ''),
+      vendor: 'nvidia',
+      backend: 'cuda',
     };
   }).filter((gpu) => gpu.name !== 'Unavailable');
+}
+
+function parseComfyStatsDevices(stats) {
+  const devices = Array.isArray(stats?.devices) ? stats.devices : [];
+  return devices.filter((device) => device && String(device.type || '').toLowerCase() !== 'cpu').map((device) => {
+    const backend = String(device.type || '').toLowerCase();
+    const rawName = String(device.name || '').replace(/^(?:cuda|hip|mps|xpu|privateuseone):\d+\s*/i, '');
+    const name = cleanName(rawName.split(' : ')[0], backend === 'mps' ? 'Apple GPU' : 'GPU');
+    const memoryBytes = Number(device.vram_total);
+    const vendor = gpuVendor(name, backend);
+    const entry = {
+      name,
+      memoryBytes: Number.isFinite(memoryBytes) && memoryBytes > 0 ? Math.round(memoryBytes) : null,
+      driver: '',
+      vendor,
+      backend,
+      source: 'comfyui',
+    };
+    if (vendor === 'apple') entry.memoryKind = 'unified';
+    return entry;
+  });
 }
 
 function runText(execFileFn, command, args, timeout = 4000) {
@@ -79,9 +112,14 @@ async function hardwareInfo(options = {}) {
     readGpuInfo(options.execFileFn || execFile),
     readDiskInfo(exportPath, options.fsPromises || fs.promises),
   ]);
-  const gpus = detectedGpus.length || platform !== 'darwin' || !/^Apple\s/i.test(cpuName)
-    ? detectedGpus
-    : [{ name: `${cpuName} GPU`, memoryBytes: totalMemory, memoryKind: 'unified', driver: '' }];
+  const connectedGpus = parseComfyStatsDevices(options.comfyStats);
+  let gpus = connectedGpus.length ? connectedGpus : detectedGpus;
+  if (!gpus.length && platform === 'darwin' && /^Apple\s/i.test(cpuName)) {
+    gpus = [{
+      name: `${cpuName} GPU`, memoryBytes: totalMemory, memoryKind: 'unified', driver: '',
+      vendor: 'apple', backend: 'mps',
+    }];
+  }
   return {
     gpu: {
       available: gpus.length > 0,
@@ -107,7 +145,9 @@ async function hardwareInfo(options = {}) {
 
 module.exports = {
   cleanName,
+  gpuVendor,
   parseNvidiaGpuCsv,
+  parseComfyStatsDevices,
   readDiskInfo,
   hardwareInfo,
 };

--- a/lib/setup-guide.js
+++ b/lib/setup-guide.js
@@ -70,6 +70,8 @@ function setupHardwareProfile(info = {}) {
   return {
     gpuAvailable: !!info?.gpu?.available,
     gpuName: String(device?.name || ''),
+    gpuVendor: String(device?.vendor || ''),
+    gpuBackend: String(device?.backend || ''),
     vramGb: bytesToGb(device?.memoryBytes),
     memoryGb: bytesToGb(info?.memory?.totalBytes),
     diskFreeGb: bytesToGb(info?.disk?.freeBytes),
@@ -106,20 +108,30 @@ function featureHardwareFit(feature = {}, hardwareInfo = {}) {
     return { level: 'unknown', label: 'Check requirements', detail: `${variant}. Hardware guidance is unavailable.`, variant };
   }
   if (!profile.gpuAvailable) {
-    return { level: 'difficult', label: 'NVIDIA GPU required', detail: `${variant}. No NVIDIA GPU was detected, so this workflow is likely to fail.`, variant };
+    return { level: 'difficult', label: 'Supported GPU required', detail: `${variant}. No supported generation GPU was detected, so this workflow is likely to fail.`, variant };
   }
+  const unsupportedVendors = Array.isArray(rules.unsupportedVendors)
+    ? rules.unsupportedVendors.map((value) => String(value).toLowerCase())
+    : [];
+  if (unsupportedVendors.includes(profile.gpuVendor.toLowerCase())) {
+    const reason = String(rules.unsupportedReason || `${variant} is not supported on this GPU backend.`);
+    return { level: 'difficult', label: 'Not supported on this GPU', detail: reason, variant, blocked: true };
+  }
+  const vendorNote = profile.gpuVendor === 'apple'
+    ? ' Apple Silicon uses unified memory; Mix Studio selects compatible BF16 assets where available.'
+    : '';
   if (!profile.vramGb) {
-    return { level: 'unknown', label: 'VRAM unknown', detail: `${variant}. The guided offload tier starts at ${minimumVram} GB VRAM; ${recommendedVram} GB is recommended.`, variant };
+    return { level: 'unknown', label: 'VRAM unknown', detail: `${variant}. The guided offload tier starts at ${minimumVram} GB VRAM; ${recommendedVram} GB is recommended.${vendorNote}`, variant };
   }
   const belowMinimum = profile.vramGb < minimumVram;
   if (belowMinimum) {
-    return { level: 'difficult', label: 'Below guided tier', detail: `${variant}. ${minimumVram} GB guided VRAM tier; ${profile.vramGb} GB detected. Installation remains available, but stronger offloading, very long runs, or out-of-memory errors are likely.`, variant };
+    return { level: 'difficult', label: 'Below guided tier', detail: `${variant}. ${minimumVram} GB guided VRAM tier; ${profile.vramGb} GB detected. Installation remains available, but stronger offloading, very long runs, or out-of-memory errors are likely.${vendorNote}`, variant };
   }
   const belowRecommended = profile.vramGb < recommendedVram;
   if (belowRecommended) {
-    return { level: 'limited', label: 'Can run with offload', detail: `${variant}. ${recommendedVram} GB VRAM is recommended. Expect slower generation and system-memory use.`, variant };
+    return { level: 'limited', label: 'Can run with offload', detail: `${variant}. ${recommendedVram} GB VRAM is recommended. Expect slower generation and system-memory use.${vendorNote}`, variant };
   }
-  return { level: 'recommended', label: 'Recommended for this PC', detail: `${variant}. Meets the ${recommendedVram} GB VRAM recommendation.`, variant };
+  return { level: 'recommended', label: 'Recommended for this PC', detail: `${variant}. Meets the ${recommendedVram} GB VRAM recommendation.${vendorNote}`, variant };
 }
 
 function componentHardwareGuidance(manifest = {}, hardwareInfo = {}) {

--- a/lib/windows-folder-picker.js
+++ b/lib/windows-folder-picker.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const path = require('path');
+const { execFile } = require('child_process');
+
+function folderPickerScript(description) {
+  const safeDescription = String(description || 'Choose a folder').replace(/'/g, "''");
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    '$selected = $null',
+    '$winFormsError = $null',
+    'try {',
+    '  Add-Type -AssemblyName System.Windows.Forms',
+    '  $dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+    `  $dialog.Description = '${safeDescription}'`,
+    '  $dialog.ShowNewFolderButton = $false',
+    '  if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { $selected = $dialog.SelectedPath }',
+    '} catch {',
+    '  $winFormsError = $_.Exception.Message',
+    '  try {',
+    '    $shell = New-Object -ComObject Shell.Application',
+    `    $folder = $shell.BrowseForFolder(0, '${safeDescription}', 0, 0)`,
+    '    if ($folder) { $selected = $folder.Self.Path }',
+    '  } catch {',
+    '    [Console]::Error.Write("WinForms picker: $winFormsError; Shell picker: $($_.Exception.Message)")',
+    '    exit 2',
+    '  }',
+    '}',
+    'if ($selected) { [Console]::Out.Write($selected) }',
+  ].join("\n");
+}
+
+function browseWindowsFolder(kind, options = {}) {
+  const env = options.env || process.env;
+  const execFileFn = options.execFileFn || execFile;
+  const pathApi = options.pathApi || path;
+  const systemRoot = String(env.SystemRoot || 'C:\\Windows');
+  const powershell = options.powershell
+    || pathApi.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  const description = kind === 'models' ? 'Choose the ComfyUI models folder' : 'Choose the ComfyUI folder';
+  const script = folderPickerScript(description);
+  return new Promise((resolve, reject) => {
+    execFileFn(powershell, ['-NoProfile', '-STA', '-Command', script], {
+      windowsHide: true,
+      timeout: options.timeoutMs || 10 * 60 * 1000,
+      maxBuffer: 64 * 1024,
+    }, (error, stdout, stderr) => {
+      if (!error) return resolve(String(stdout || '').trim());
+      const diagnostic = String(stderr || '').trim() || String(error.message || error);
+      const wrapped = new Error(`Windows could not open the folder picker. Enter the folder path manually, or retry after signing into the generation desktop. ${diagnostic}`);
+      wrapped.code = 'folder_picker_failed';
+      wrapped.cause = error;
+      reject(wrapped);
+    });
+  });
+}
+
+module.exports = {
+  browseWindowsFolder,
+  folderPickerScript,
+};

--- a/public/app.js
+++ b/public/app.js
@@ -189,6 +189,7 @@ const state = {
   selected: new Set(),
   connOk: false,
   features: {},              // machine-level installer choices, all on by default
+  videoCapabilities: {},     // connected-device support reported by the server
 };
 
 const ASPECTS = [
@@ -249,25 +250,52 @@ function promoteEngineDefault(order, preferred, engines) {
 function featureEnabled(key) { return state.features[key] !== false; }
 function enabledEditEngines() { return normalizeEngineOrder(state.editEngineOrder, EDIT_ENGINES).filter((engine) => featureEnabled(EDIT_FEATURES[engine])); }
 function enabledVideoEngines() { return normalizeEngineOrder(state.videoEngineOrder, VIDEO_ENGINES).filter((engine) => featureEnabled(VIDEO_FEATURES[engine])); }
+function videoEngineCapability(engine) {
+  return state.videoCapabilities?.[engine] || { supported: true, reason: '' };
+}
+function videoEngineSupported(engine) { return videoEngineCapability(engine).supported !== false; }
+function supportedVideoEngines() { return enabledVideoEngines().filter(videoEngineSupported); }
+function capabilityEngineForButton(button) {
+  if (VIDEO_ENGINES.includes(button?.dataset?.engine)) return button.dataset.engine;
+  if (button?.matches?.('[data-director-entry]')) return 'ltx';
+  const feature = button?.dataset?.featureEngine;
+  return Object.keys(VIDEO_FEATURES).find((engine) => VIDEO_FEATURES[engine] === feature) || '';
+}
+function applyVideoCapability(button) {
+  const engine = capabilityEngineForButton(button);
+  if (!engine) return;
+  const capability = videoEngineCapability(engine);
+  button.disabled = capability.supported === false;
+  button.setAttribute('aria-disabled', String(button.disabled));
+  if (button.disabled) {
+    button.title = capability.reason || 'This video model is not supported on the connected generation device.';
+  } else if (button.title === button.dataset.capabilityReason) {
+    button.removeAttribute('title');
+  }
+  button.dataset.capabilityReason = capability.reason || '';
+}
 function supportsCurrentEditAngles() { return state.view === 'edit' && ANGLE_EDIT_ENGINES.has(state.editEngine); }
 
 function renderFeatureVisibility() {
   applySavedEngineOrders();
   const editEngines = enabledEditEngines();
   const videoEngines = enabledVideoEngines();
+  const supportedVideos = videoEngines.filter(videoEngineSupported);
   const hasEdit = editEngines.length > 0;
-  const hasVideo = videoEngines.length > 0;
+  const hasVideo = supportedVideos.length > 0;
   $$('[data-feature-engine]').forEach((button) => {
     button.hidden = !featureEnabled(button.dataset.featureEngine);
+    applyVideoCapability(button);
   });
   $$('[data-feature-view="edit"]').forEach((button) => { button.hidden = !hasEdit; });
   $$('[data-feature-view="video"]').forEach((button) => { button.hidden = !hasVideo; });
   $$('#animEngineRow .chip[data-engine]').forEach((button) => {
     button.hidden = !featureEnabled(VIDEO_FEATURES[button.dataset.engine]);
+    applyVideoCapability(button);
   });
   if (editEngines.length && !editEngines.includes(state.editEngine)) switchEditEngine(editEngines[0]);
-  if (videoEngines.length && !videoEngines.includes(state.vidEngine)) state.vidEngine = videoEngines[0];
-  if (videoEngines.length && !videoEngines.includes(state.animEngine)) state.animEngine = videoEngines[0];
+  if (supportedVideos.length && !supportedVideos.includes(state.vidEngine)) state.vidEngine = supportedVideos[0];
+  if (supportedVideos.length && !supportedVideos.includes(state.animEngine)) state.animEngine = supportedVideos[0];
   markEngineRow('editEngineRow', state.editEngine);
   markEngineRow('vidEngineRow', state.vidEngine);
   markEngineRow('animEngineRow', state.animEngine);
@@ -11397,7 +11425,13 @@ function renderEngineInfoList(kind = 'video') {
     button.dataset.engine = engine;
     button.classList.toggle('active', engine === current);
     button.setAttribute('aria-pressed', String(engine === current));
+    const capability = editing ? { supported: true, reason: '' } : videoEngineCapability(engine);
+    button.disabled = capability.supported === false;
     button.setAttribute('aria-label', `Use ${definition.model}${definition.experimental ? ' (experimental)' : ''} for ${definition.task}`);
+    if (button.disabled) {
+      button.setAttribute('aria-label', `${definition.model} is unavailable. ${capability.reason}`);
+      button.title = capability.reason;
+    }
     const hasPreview = !!definition.preview;
     button.classList.toggle('text-only', !hasPreview);
     if (hasPreview) button.appendChild(createEngineInfoPreview(definition.preview));
@@ -11414,10 +11448,16 @@ function renderEngineInfoList(kind = 'video') {
       badge.textContent = 'Experimental';
       titleRow.appendChild(badge);
     }
+    if (button.disabled) {
+      const badge = document.createElement('span');
+      badge.className = 'model-status-badge unsupported';
+      badge.textContent = 'Unavailable';
+      titleRow.appendChild(badge);
+    }
     const model = document.createElement('small');
     model.textContent = `${definition.task}${definition.detail ? ` · ${definition.detail}` : ''}`;
     const description = document.createElement('p');
-    description.textContent = definition.copy;
+    description.textContent = button.disabled ? capability.reason : definition.copy;
     copy.append(titleRow, model, description);
     const check = document.createElement('i');
     check.className = 'engine-info-check';
@@ -14699,7 +14739,7 @@ function pickRef(idx) {
 
 async function sendToVideoTab(item, role = 'start') {
   try {
-    const enabled = enabledVideoEngines();
+    const enabled = supportedVideoEngines();
     if (role === 'end' && !['ltx', 'eros'].includes(state.vidEngine)) {
       const endEngine = ['ltx', 'eros'].find((engine) => enabled.includes(engine));
       if (!endEngine) throw new Error('Enable LTX 2.3 or 10Eros to use a gallery image as the last frame');
@@ -15672,7 +15712,8 @@ function modelOrderButtons(rowId, visibleOnly = false) {
 
 function firstEnabledModel(config) {
   return normalizeEngineOrder(state[config.orderKey], config.engines)
-    .find((engine) => featureEnabled(config.features[engine]));
+    .find((engine) => featureEnabled(config.features[engine])
+      && (config.kind !== 'Video' || videoEngineSupported(engine)));
 }
 
 function syncModelOrderDefault(rowId) {
@@ -15690,6 +15731,7 @@ function syncModelOrderDefault(rowId) {
     button.setAttribute('aria-label', isDefault ? `${label}, default model` : label);
     button.setAttribute('aria-roledescription', 'draggable model');
     button.title = isDefault ? `${label} · default for the next session` : 'Hold and drag to reorder';
+    if (rowId === 'vidEngineRow') applyVideoCapability(button);
   });
 }
 
@@ -16024,6 +16066,10 @@ $('#generateBtn').addEventListener('click', async () => {
   if (outpaintActive && !editOutpaintGeometry().valid) return toast('Reduce Source on canvas below 100%, or choose a different Resolution ratio', true);
 
   if (state.view === 'video') {
+    const capability = videoEngineCapability(state.vidEngine);
+    if (capability.supported === false) {
+      return toast(capability.reason || 'This video model is not supported on the connected generation device.', true);
+    }
     const ltxEdit = state.vidEngine === 'ltx-edit';
     if (!ltxEdit && state.vidEngine !== 'ltx' && !state.vidRef) {
       const lbl = { wan: 'Wan 2.2', eros: '10Eros DMD', scail: 'SCAIL 2' }[state.vidEngine];
@@ -17992,7 +18038,7 @@ function resetActiveGenerationForm() {
     state.videoCameraMotions = [];
     state.videoCameraMotionPhrase = '';
     state.videoCameraGuide = null;
-    state.vidEngine = enabledVideoEngines()[0] || state.videoEngineDefault || 'ltx';
+    state.vidEngine = supportedVideoEngines()[0] || state.videoEngineDefault || 'ltx';
     $('#vidDriveVideo').removeAttribute('src');
     $('#vidDriveTrimChip').classList.remove('active');
     setAudioChipVisual($('#vidAudioChip'), false);
@@ -30217,6 +30263,7 @@ async function loadMeta(refresh, afterRestart = false) {
     state.metaLorasInfo = lastMeta.lorasInfo || {};
     state.loraThumbs = lastMeta.loraThumbs || {};
     state.features = lastMeta.features || {};
+    state.videoCapabilities = lastMeta.capabilities?.video || {};
     renderFeatureVisibility();
     $('#connDot').className = 'conn-dot ' + (lastMeta.ok ? 'ok' : 'bad');
     renderKrea2Mode();

--- a/public/app.js
+++ b/public/app.js
@@ -25546,7 +25546,7 @@ function renderHardwareInfo(info) {
     gpu.memoryBytes ? `${formatHardwareBytes(gpu.memoryBytes)} ${gpu.memoryKind === 'unified' ? 'unified memory' : 'VRAM'}` : '',
     gpu.driver ? `driver ${gpu.driver}` : '',
     gpuDevices.length > 1 ? `+${gpuDevices.length - 1} more` : '',
-  ].filter(Boolean).join(' · ') : 'No NVIDIA GPU reported by the system';
+  ].filter(Boolean).join(' · ') : 'No compatible GPU reported by the system';
   setHardwareRow('hardwareGpu', 'hardwareGpuDetail', gpu?.name || 'Unavailable', gpuDetail);
 
   const cores = Number(info?.cpu?.logicalCores) || 0;
@@ -29214,7 +29214,7 @@ function renderPhoneAccess() {
     $('#phoneAccessTitle').textContent = 'Try the same Wi-Fi now';
     $('#phoneAccessDescription').textContent = `The address below works while both devices are on this network. ${pinProtected ? 'The Owner profile is PIN-protected.' : 'A PIN is optional, but anyone who can reach this address can use Owner.'} Install Tailscale for private access away from home.`;
   } else {
-    $('#phoneAccessStatus').textContent = 'Install Tailscale on this PC and your phone';
+    $('#phoneAccessStatus').textContent = 'Install Tailscale on this computer and your phone';
     $('#phoneAccessTitle').textContent = 'Set up private phone access';
     $('#phoneAccessDescription').textContent = 'Install Tailscale on both devices and sign in to the same tailnet. Mix Studio will show the private address here after it detects the connection.';
   }
@@ -29230,6 +29230,12 @@ function renderPhoneAccess() {
     ? `${access.secureUrl ? 'Installable private HTTPS address' : 'Private Tailscale address'} is ready${pinProtected ? ' and PIN-protected' : '; profile PIN is optional'}.`
     : (access.localUrl ? `Same-Wi-Fi access is ready${pinProtected ? ' and PIN-protected' : '; profile PIN is optional'}.` : 'Set up private phone access with Tailscale.');
   if ($('#phoneAccessSettingsStatus')) $('#phoneAccessSettingsStatus').textContent = access.tailscaleDetected || access.localUrl ? 'Ready' : 'Guide';
+}
+
+function setupLocalPath(base, child) {
+  const root = String(base || '').replace(/[\\/]+$/, '');
+  if (!root) return '';
+  return `${root}${setupViewStatus?.platform === 'win32' ? '\\' : '/'}${child}`;
 }
 
 function renderInitialSetup() {
@@ -29297,9 +29303,10 @@ function renderInitialSetup() {
 
   const hardware = setupViewStatus.hardware || {};
   const quickFit = setupViewStatus.quickFit || {};
+  const generationMemoryName = hardware.gpuBackend === 'mps' ? 'unified memory' : 'VRAM';
   $('#setupHardwareCopy').textContent = hardware.gpuAvailable
-    ? `${hardware.gpuName || 'NVIDIA GPU'}${hardware.vramGb ? ` · ${hardware.vramGb} GB VRAM` : ' · VRAM unavailable'}${hardware.memoryGb ? ` · ${hardware.memoryGb} GB RAM` : ''}`
-    : 'No NVIDIA GPU detected';
+    ? `${hardware.gpuName || 'GPU'}${hardware.vramGb ? ` · ${hardware.vramGb} GB ${generationMemoryName}` : ` · ${generationMemoryName} unavailable`}${hardware.memoryGb && hardware.gpuBackend !== 'mps' ? ` · ${hardware.memoryGb} GB RAM` : ''}`
+    : 'No compatible GPU detected';
   $('#setupHardwareFit').textContent = krea2CoreBlocked
     ? 'Update ComfyUI for Krea 2'
     : (int8Blocked ? 'Update ComfyUI for native Krea INT8' : (quickFit.label || 'Compatibility not yet available'));
@@ -29332,7 +29339,9 @@ function renderInitialSetup() {
   $('#setupKrea2Variant').disabled = busy || !state.profileIsOwner;
 
   const pathValue = comfy.configuredPath || comfy.detectedPath || '';
-  const modelsValue = comfy.modelsPath || (pathValue ? `${pathValue.replace(/[\\/]+$/, '')}\\models` : '');
+  const modelsValue = comfy.modelsPath || setupLocalPath(pathValue, 'models');
+  $('#setupComfyPath').placeholder = setupViewStatus.platform === 'darwin' ? '/Users/you/ComfyUI' : 'C:\\ComfyUI';
+  $('#setupModelsPath').placeholder = setupViewStatus.platform === 'darwin' ? '/Users/you/ComfyUI/models' : 'C:\\ComfyUI\\models';
   if (document.activeElement !== $('#setupComfyUrl')) $('#setupComfyUrl').value = comfy.url || 'http://127.0.0.1:8188';
   if (document.activeElement !== $('#setupComfyPath') && !$('#setupComfyPath').value) $('#setupComfyPath').value = pathValue;
   if (document.activeElement !== $('#setupModelsPath') && !$('#setupModelsPath').value) $('#setupModelsPath').value = modelsValue;
@@ -29354,7 +29363,9 @@ function renderInitialSetup() {
   $('#setupCoreUpdate').hidden = !krea2CoreBlocked;
   $('#setupCoreUpdateCopy').textContent = start.kind === 'desktop'
     ? `${setupKrea2CoreMessage()} On the generation computer, use Comfy Desktop → Menu → Help → Check for Updates.`
-    : `${setupKrea2CoreMessage()} For Portable, run update\\update_comfyui.bat from the portable folder.`;
+    : (setupViewStatus.platform === 'darwin'
+      ? `${setupKrea2CoreMessage()} Update the source checkout from Terminal, then restart ComfyUI.`
+      : `${setupKrea2CoreMessage()} For Portable, run update\\update_comfyui.bat from the portable folder.`);
   $('#setupCoreUpdateCheck').disabled = busy;
   const endpointMatches = setupDiscoveredMatches.length ? setupDiscoveredMatches : (start.matches || []);
   renderSetupEndpointChoices(endpointMatches);
@@ -29378,15 +29389,16 @@ function renderInitialSetup() {
     : (nodeSetupActive ? 'Resolve the install issue from the Install step. Paths remain available below.' : 'Start a detected installation or choose another location. Mix Studio finds the port automatically.'));
   $('#setupUseDetected').disabled = busy || !comfy.detectedPath || !state.profileIsOwner;
   $('#setupInstallComfy').disabled = busy || !comfy.canInstallOfficial || !state.profileIsOwner;
+  $('#setupInstallComfy').hidden = !comfy.canInstallOfficial;
   $('#setupInstallComfy').title = comfy.canInstallOfficial ? 'Opens the official Comfy Desktop app or downloads its signed installer' : 'Available when Mix Studio is running on Windows';
   $('#setupSaveConnection').disabled = busy || !state.profileIsOwner;
-  const canBrowse = setupViewStatus.platform === 'win32' && state.profileIsOwner && !busy;
+  const canBrowse = ['win32', 'darwin'].includes(setupViewStatus.platform) && state.profileIsOwner && !busy;
   $('#setupBrowseComfy').disabled = !canBrowse;
   $('#setupBrowseComfyDetails').disabled = !canBrowse;
   $('#setupBrowseModels').disabled = !canBrowse;
-  const browseTitle = setupViewStatus.platform === 'win32'
+  const browseTitle = ['win32', 'darwin'].includes(setupViewStatus.platform)
     ? 'Opens a folder picker on the generation computer'
-    : 'Browse opens on the Windows generation computer. Enter the path manually here.';
+    : 'Folder browsing is not available on this generation computer. Enter the absolute path manually here.';
   $('#setupBrowseComfy').title = browseTitle;
   $('#setupBrowseComfyDetails').title = browseTitle;
   $('#setupBrowseModels').title = browseTitle;
@@ -29622,7 +29634,7 @@ async function saveSetupConnection(pathOverride) {
     body: JSON.stringify({
       url: $('#setupComfyUrl').value.trim(),
       path: pathValue,
-      modelsPath: $('#setupModelsPath').value.trim() || (pathValue ? `${pathValue.replace(/[\\/]+$/, '')}\\models` : ''),
+      modelsPath: $('#setupModelsPath').value.trim() || setupLocalPath(pathValue, 'models'),
     }),
   });
   setupViewStatus = result;
@@ -29821,7 +29833,7 @@ $('#setupUseDetected').addEventListener('click', async () => {
     const detected = setupViewStatus?.comfy?.detectedPath;
     if (!detected) return;
     $('#setupComfyPath').value = detected;
-    $('#setupModelsPath').value = `${detected.replace(/[\\/]+$/, '')}\\models`;
+    $('#setupModelsPath').value = setupLocalPath(detected, 'models');
     await saveSetupConnection(detected);
   } catch (error) { toast(error.message, true); }
 });
@@ -29841,7 +29853,7 @@ async function browseSetupDirectory(kind, trigger) {
       $('#setupModelsPath').value = result.directory;
     } else {
       $('#setupComfyPath').value = result.directory;
-      $('#setupModelsPath').value = `${result.directory.replace(/[\\/]+$/, '')}\\models`;
+      $('#setupModelsPath').value = setupLocalPath(result.directory, 'models');
       await saveSetupConnection(result.directory);
     }
   } catch (error) {

--- a/public/index.html
+++ b/public/index.html
@@ -2211,7 +2211,7 @@
           </button>
           <button class="setup-choice setup-choice-violet" id="setupBrowseComfy" type="button">
             <span class="setup-choice-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3.5 6.5h6l2 2h9v9.5a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2V6.5Z"/></svg></span>
-            <span><strong>Browse computer</strong><small>Choose the ComfyUI folder on the generation PC.</small></span><i aria-hidden="true">›</i>
+            <span><strong>Browse computer</strong><small>Choose the local ComfyUI source folder.</small></span><i aria-hidden="true">›</i>
           </button>
           <button class="setup-choice setup-choice-red" id="setupInstallComfy" type="button">
             <span class="setup-choice-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3v12m0 0 4-4m-4 4-4-4M4 19h16"/></svg></span>
@@ -2291,7 +2291,7 @@
             </div>
             <div class="phone-access-copy">
               <h4 id="phoneAccessTitle">Open Mix Studio on your phone</h4>
-              <p id="phoneAccessDescription">Install Tailscale on this Windows PC and your phone, sign in to the same tailnet, then open the private address below.</p>
+              <p id="phoneAccessDescription">Install Tailscale on this computer and your phone, sign in to the same tailnet, then open the private address below.</p>
               <ol><li>Install Tailscale on both devices.</li><li>Sign in to the same Tailscale network.</li><li>Open the Mix Studio address on your phone.</li></ol>
             </div>
             <div class="phone-access-url" id="phoneAccessUrl" hidden><code></code><button id="phoneAccessCopy" type="button">Copy address</button></div>

--- a/public/style.css
+++ b/public/style.css
@@ -2231,6 +2231,9 @@ body.model-order-dragging .video-choice-grid .chip[data-engine] { cursor: grabbi
 .engine-info-card:hover,
 .engine-info-card:focus-visible { border-color: rgba(var(--mode-rgb),.48); background: rgba(var(--mode-rgb),.07); }
 .engine-info-card.active { border-color: rgba(var(--mode-rgb),.62); background: rgba(var(--mode-rgb),.1); box-shadow: inset 0 0 0 1px rgba(var(--mode-rgb),.16); }
+.engine-info-card:disabled { cursor: not-allowed; opacity: .58; border-color: rgba(255,255,255,.08); }
+.engine-info-card:disabled:hover { background: rgba(255,255,255,.025); border-color: rgba(255,255,255,.08); }
+.model-status-badge.unsupported { color: #ffb1ad; border-color: rgba(255,93,87,.34); background: rgba(255,93,87,.12); }
 .engine-info-preview {
   position: relative;
   width: 100%;

--- a/server.js
+++ b/server.js
@@ -205,7 +205,7 @@ const {
 } = require('./lib/mobile-access');
 const { hardwareInfo } = require('./lib/hardware-info');
 const { isWidgetSpec } = require('./lib/comfy-widget-spec');
-const { browseWindowsFolder } = require('./lib/windows-folder-picker');
+const { browseGenerationFolder } = require('./lib/folder-picker');
 const {
   appleGenerationProfile,
   configuredVideoEngineCapability,
@@ -1005,11 +1005,6 @@ function stopOfficialComfySetup() {
     try { child.kill('SIGTERM'); } catch { /* process may already be gone */ }
   }
   return true;
-}
-
-function browseGenerationFolder(kind) {
-  if (process.platform !== 'win32') throw new Error('Folder browsing is available on the Windows generation computer. Enter the location manually here.');
-  return browseWindowsFolder(kind);
 }
 
 async function assertDesktopIsIdle() {
@@ -8484,7 +8479,7 @@ function scheduleServerRestart() {
   broadcast('appRestarting', {});
   setTimeout(() => {
     const restartMode = process.env.MIXBOX_RESTART_MODE || process.env.KREASTUDIO_RESTART_MODE;
-    if (restartMode !== 'batch') launchDetachedReplacement();
+    if (!['batch', 'launcher'].includes(restartMode)) launchDetachedReplacement();
     for (const client of sseClients.keys()) {
       try { client.end(); } catch { /* noop */ }
     }

--- a/server.js
+++ b/server.js
@@ -204,6 +204,15 @@ const {
   tailscaleHttpsStatus,
 } = require('./lib/mobile-access');
 const { hardwareInfo } = require('./lib/hardware-info');
+const { isWidgetSpec } = require('./lib/comfy-widget-spec');
+const { browseWindowsFolder } = require('./lib/windows-folder-picker');
+const {
+  appleGenerationProfile,
+  configuredVideoEngineCapability,
+  configuredVideoEngineCapabilities,
+  dependencyComponentBlock,
+  ltxRefinePreflight,
+} = require('./lib/generation-capabilities');
 const {
   buildKrea2ModelLoader,
   effectiveKrea2Variant,
@@ -457,6 +466,15 @@ function settingsResponse() {
   });
   delete response.hfToken;
   return response;
+}
+
+function adoptDeviceCompatibleModelSettings(hardwareProfile = {}) {
+  if (!appleGenerationProfile(hardwareProfile)) return false;
+  const configured = normalizeModelPath(settings.ltxCkpt).split('/').pop();
+  if (configured && configured !== 'ltx-2.3-22b-dev-fp8.safetensors') return false;
+  settings.ltxCkpt = 'ltx-2.3-22b-dev.safetensors';
+  saveJsonSync(SETTINGS_FILE, settings);
+  return true;
 }
 
 function seedVr2ModelDirs() {
@@ -836,7 +854,12 @@ function updateComfyStartState(patch) {
 
 async function getSetupHardwareInfo(force = false) {
   if (!force && setupHardwareSnapshot && Date.now() - setupHardwareAt < 5 * 60 * 1000) return setupHardwareSnapshot;
-  setupHardwareSnapshot = await hardwareInfo({ exportPath: settings.exportDir || DATA });
+  let comfyStats = null;
+  try {
+    const response = await comfyFetch('/system_stats', { signal: AbortSignal.timeout(4000) });
+    comfyStats = await response.json();
+  } catch { /* local detection remains available while ComfyUI is offline */ }
+  setupHardwareSnapshot = await hardwareInfo({ exportPath: settings.exportDir || DATA, comfyStats });
   setupHardwareAt = Date.now();
   return setupHardwareSnapshot;
 }
@@ -986,26 +1009,7 @@ function stopOfficialComfySetup() {
 
 function browseGenerationFolder(kind) {
   if (process.platform !== 'win32') throw new Error('Folder browsing is available on the Windows generation computer. Enter the location manually here.');
-  const systemRoot = String(process.env.SystemRoot || 'C:\\Windows');
-  const powershell = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
-  const description = kind === 'models' ? 'Choose the ComfyUI models folder' : 'Choose the ComfyUI folder';
-  const script = [
-    'Add-Type -AssemblyName System.Windows.Forms',
-    '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
-    `$dialog.Description = '${description}'`,
-    '$dialog.ShowNewFolderButton = $false',
-    'if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($dialog.SelectedPath) }',
-  ].join('; ');
-  return new Promise((resolve, reject) => {
-    execFile(powershell, ['-NoProfile', '-STA', '-Command', script], {
-      windowsHide: true,
-      timeout: 10 * 60 * 1000,
-      maxBuffer: 64 * 1024,
-    }, (error, stdout) => {
-      if (error) return reject(error);
-      resolve(String(stdout || '').trim());
-    });
-  });
+  return browseWindowsFolder(kind);
 }
 
 async function assertDesktopIsIdle() {
@@ -1215,10 +1219,33 @@ async function directorInputAssetAvailable(name) {
 
 let objectInfoCache = null;
 let objectInfoAt = 0;
-async function getObjectInfo(force, fetchOptions) {
+const COMFY_OBJECT_INFO_TIMEOUT_MS = 60_000;
+
+function comfyRequestTimedOut(error) {
+  for (let current = error; current; current = current.cause) {
+    if (['AbortError', 'TimeoutError'].includes(current?.name)) return true;
+    if (/timed?\s*out|timeout/i.test(String(current?.message || ''))) return true;
+  }
+  return false;
+}
+
+async function getObjectInfo(force, fetchOptions = {}) {
   if (!force && objectInfoCache && Date.now() - objectInfoAt < 5 * 60 * 1000) return objectInfoCache;
-  const res = await comfyFetch('/object_info', fetchOptions);
-  objectInfoCache = await res.json();
+  const options = Object.assign({}, fetchOptions);
+  if (!options.signal) options.signal = AbortSignal.timeout(COMFY_OBJECT_INFO_TIMEOUT_MS);
+  let res;
+  try {
+    res = await comfyFetch('/object_info', options);
+    objectInfoCache = await res.json();
+  } catch (error) {
+    if (!comfyRequestTimedOut(error)) throw error;
+    const wrapped = new Error(
+      'ComfyUI took longer than 60 seconds to describe its installed nodes. It may still be loading custom nodes; wait for the ComfyUI console to settle, then Check again.'
+    );
+    wrapped.code = 'comfy_object_info_timeout';
+    wrapped.cause = error;
+    throw wrapped;
+  }
   objectInfoAt = Date.now();
   adoptRegisteredModelPaths(objectInfoCache);
   return objectInfoCache;
@@ -1507,14 +1534,6 @@ async function loraMetadataMap(loras, force) {
   }
   loraInfoCache = { key, at: Date.now(), value };
   return value;
-}
-
-function isWidgetSpec(spec) {
-  if (!Array.isArray(spec)) return false;
-  const t = spec[0];
-  if (Array.isArray(t)) return true; // combo
-  if (typeof t === 'string' && t.startsWith('COMFY_') && t.includes('COMBO')) return true; // V3 DynamicCombo
-  return ['INT', 'FLOAT', 'STRING', 'BOOLEAN', 'COMBO'].includes(t);
 }
 
 /**
@@ -5011,6 +5030,11 @@ function dependencyComponentInfo(id, fit = null) {
 
 function setupDependencyComponentInfo(id, fit, krea2Core) {
   const component = dependencyComponentInfo(id, fit);
+  if (fit?.blocked) {
+    component.installable = false;
+    component.blockedBy = 'hardware';
+    component.installReason = fit.detail || 'This workflow is not supported on the connected generation device.';
+  }
   if (krea2Core && krea2Core.supported !== true && KREA2_DEPENDENCY_COMPONENTS.has(id)) {
     component.installable = false;
     component.blockedBy = 'comfy-core';
@@ -5053,6 +5077,7 @@ async function setupStatusPayload(forceCompatibility = false) {
   });
   const hardwareInfoValue = await getSetupHardwareInfo();
   const hardwareProfile = setupHardwareProfile(hardwareInfoValue);
+  adoptDeviceCompatibleModelSettings(hardwareProfile);
   const krea2Recommendation = recommendedKrea2Variant(hardwareProfile);
   const vramRecommendation = recommendedVramProfile(hardwareProfile);
   const guidance = componentHardwareGuidance(SETUP_FEATURE_MANIFEST, hardwareInfoValue);
@@ -5061,7 +5086,7 @@ async function setupStatusPayload(forceCompatibility = false) {
   let connectionError = '';
   let info = null;
   try {
-    info = await getObjectInfo(forceCompatibility, { signal: AbortSignal.timeout(4000) });
+    info = await getObjectInfo(forceCompatibility);
     connected = true;
   } catch (error) {
     connectionError = String(error.message || error);
@@ -5079,6 +5104,7 @@ async function setupStatusPayload(forceCompatibility = false) {
     quickSetup,
     quickFit: combinedHardwareFit(quickSetup.components, guidance),
     hardware: hardwareProfile,
+    capabilities: { video: configuredVideoEngineCapabilities(hardwareProfile, settings) },
     modelRecommendations: { krea2: krea2Recommendation },
     modelVariants: { krea2: settings.krea2ModelVariant },
     vramProfile: {
@@ -5678,7 +5704,7 @@ async function handleApi(req, res, url) {
   }
   if (route === '/api/hardware' && req.method === 'GET') {
     try {
-      return json(res, 200, await hardwareInfo({ exportPath: settings.exportDir || DATA }));
+      return json(res, 200, await getSetupHardwareInfo(true));
     } catch (error) {
       return json(res, 500, { error: String(error.message || error) });
     }
@@ -5720,13 +5746,17 @@ async function handleApi(req, res, url) {
   if (route === '/api/meta') {
     const app = Object.assign(readAppRelease(ROOT), { instanceId: SERVER_INSTANCE_ID });
     try {
-      const info = await getObjectInfo(url.searchParams.has('refresh'), { signal: AbortSignal.timeout(6000) });
+      const info = await getObjectInfo(url.searchParams.has('refresh'));
       const loras = (info.LoraLoader?.input?.required?.lora_name?.[0]) || [];
       const lorasInfo = await loraMetadataMap(loras, url.searchParams.has('refresh'));
       const missing = {};
       for (const [group, classes] of Object.entries(REQUIRED_CLASSES)) {
         missing[group] = classes.filter((c) => !info[c]);
       }
+      const hardwareInfoValue = await getSetupHardwareInfo(url.searchParams.has('refresh'));
+      const hardwareProfile = setupHardwareProfile(hardwareInfoValue);
+      adoptDeviceCompatibleModelSettings(hardwareProfile);
+      const hardwareGuidance = componentHardwareGuidance(SETUP_FEATURE_MANIFEST, hardwareInfoValue);
       const models = configuredModelsStatus(info);
       const installStatus = sam3InstallStatus(RUNTIME);
       const missingComponents = missingDependencyComponentIds(missing, models);
@@ -5765,7 +5795,7 @@ async function handleApi(req, res, url) {
           canInstall: installStatus.canInstall,
           reason: installStatus.reason,
           restart: Object.assign(restartStatus(RUNTIME), { running: comfyRestartRunning }),
-          components: availableComponents().map((id) => dependencyComponentInfo(id)),
+          components: availableComponents().map((id) => setupDependencyComponentInfo(id, hardwareGuidance[id] || null, null)),
           missingComponents,
           install: dependencyInstallState,
           sam3: { canInstall: installStatus.canInstall, downloaded: installStatus.downloaded, reason: installStatus.reason },
@@ -5781,6 +5811,7 @@ async function handleApi(req, res, url) {
           outpaintLora: settings.krea2OutpaintLora,
         },
         features: settings.features,
+        capabilities: { video: configuredVideoEngineCapabilities(hardwareProfile, settings) },
         queue: jobs.size,
       });
     } catch (e) {
@@ -6025,10 +6056,22 @@ async function handleApi(req, res, url) {
     const modelVariants = { krea2: krea2Variant };
     const components = [...new Set(requested.filter((id) => Object.prototype.hasOwnProperty.call(DEPENDENCY_COMPONENTS, id)))];
     if (!components.length) return json(res, 400, { error: 'Choose at least one missing model or node group to install.' });
+    const hardwareProfile = setupHardwareProfile(await getSetupHardwareInfo());
+    adoptDeviceCompatibleModelSettings(hardwareProfile);
+    const hardwareBlocked = components
+      .map((id) => ({ id, reason: dependencyComponentBlock(id, hardwareProfile) }))
+      .find((entry) => entry.reason);
+    if (hardwareBlocked) {
+      return json(res, 409, {
+        error: hardwareBlocked.reason,
+        code: 'generation_device_unsupported',
+        component: hardwareBlocked.id,
+      });
+    }
     const installsKrea2 = components.some((id) => KREA2_DEPENDENCY_COMPONENTS.has(id));
     if (installsKrea2) {
       try {
-        const info = await getObjectInfo(true, { signal: AbortSignal.timeout(4000) });
+        const info = await getObjectInfo(true);
         const coreCompatibility = await getComfyCompatibility(true);
         const krea2Compatibility = krea2ClipCompatibility(info, coreCompatibility.version);
         if (krea2Compatibility.supported !== true) {
@@ -6062,7 +6105,7 @@ async function handleApi(req, res, url) {
     let availableModelNames = [];
     try {
       availableModelNames = [...registeredModelNames(
-        await getObjectInfo(true, { signal: AbortSignal.timeout(4000) }),
+        await getObjectInfo(true),
       )];
     } catch { /* ComfyUI may be stopped during installation. */ }
     let availableModelRoots = [RUNTIME.comfy.modelsPath].filter(Boolean);
@@ -6094,6 +6137,8 @@ async function handleApi(req, res, url) {
             availableModelNames,
             availableModelRoots,
             modelVariants,
+            gpuVendor: hardwareProfile.gpuVendor,
+            platform: process.platform,
             hfToken: settings.hfToken,
             hfEndpoint: settings.hfEndpoint,
           },
@@ -6843,6 +6888,16 @@ async function handleApi(req, res, url) {
     if (settings.features[VIDEO_FEATURES[engine]] === false) {
       return json(res, 400, { error: 'This video model was not installed on this machine.' });
     }
+    const generationHardwareProfile = setupHardwareProfile(await getSetupHardwareInfo());
+    adoptDeviceCompatibleModelSettings(generationHardwareProfile);
+    const engineCapability = configuredVideoEngineCapability(engine, generationHardwareProfile, settings);
+    if (!engineCapability.supported) {
+      return json(res, 409, {
+        error: engineCapability.reason,
+        code: 'generation_device_unsupported',
+        engine,
+      });
+    }
     const requestedCameraMotions = normalizeCameraMotions(body.cameraMotions);
     const blockedCameraMotionPhrase = engine === 'scail' ? cameraMotionPhrase(requestedCameraMotions) : '';
     const cameraMotions = engine === 'scail' ? [] : requestedCameraMotions;
@@ -6982,6 +7037,19 @@ async function handleApi(req, res, url) {
         cameraReferenceGuided ? LTX_CAMERA_MAX_SECONDS : (isLtxEdit ? 15 : LTX_MAX_SECONDS)
       );
       ({ W, H } = cameraReferenceGuided ? cameraMotionDims(srcW, srcH) : videoDims(srcW, srcH));
+    }
+
+    if ((engine === 'ltx' || isLtxEdit) && !faceImageName) {
+      const refinePreflight = ltxRefinePreflight({
+        width: W, height: H, frames, fps, profile: generationHardwareProfile,
+      });
+      if (!refinePreflight.ok) {
+        return json(res, 409, Object.assign({
+          error: refinePreflight.error,
+          code: 'ltx_refine_too_large',
+          engine,
+        }, refinePreflight));
+      }
     }
 
     const requestedSeed = Number(body.seed);

--- a/start.command
+++ b/start.command
@@ -1,0 +1,36 @@
+#!/bin/zsh
+
+set -u
+
+SCRIPT_DIR="${0:A:h}"
+cd "$SCRIPT_DIR" || exit 1
+
+NODE_EXE="${MIX_STUDIO_NODE:-}"
+if [[ -z "$NODE_EXE" ]]; then
+  NODE_EXE="$(command -v node 2>/dev/null || true)"
+fi
+if [[ -z "$NODE_EXE" || ! -x "$NODE_EXE" ]]; then
+  print -u2 "Node.js 22 or newer was not found. Install it from https://nodejs.org/ and run this file again."
+  exit 1
+fi
+
+NODE_MAJOR="$($NODE_EXE -p "process.versions.node.split('.')[0]" 2>/dev/null || true)"
+if [[ ! "$NODE_MAJOR" =~ '^[0-9]+$' || "$NODE_MAJOR" -lt 22 ]]; then
+  print -u2 "Mix Studio requires Node.js 22 or newer. Install the current LTS from https://nodejs.org/."
+  exit 1
+fi
+
+if [[ ! -f install.json ]]; then
+  "$NODE_EXE" installer/bootstrap.js || exit $?
+fi
+
+export MIXBOX_RESTART_MODE=launcher
+export PYTORCH_ENABLE_MPS_FALLBACK="${PYTORCH_ENABLE_MPS_FALLBACK:-1}"
+
+(sleep 1; /usr/bin/open "http://127.0.0.1:${PORT:-3300}/" >/dev/null 2>&1) &
+
+while true; do
+  "$NODE_EXE" server.js
+  STATUS=$?
+  [[ "$STATUS" -eq 75 ]] || exit "$STATUS"
+done

--- a/test/app-update.test.js
+++ b/test/app-update.test.js
@@ -145,6 +145,7 @@ test('automatic updates reject a non-official origin', async () => {
 test('server and library updates require a restart', () => {
   assert.equal(restartRequiredForFiles(['README.md', 'server.js']), true);
   assert.equal(restartRequiredForFiles(['lib/profiles.js']), true);
+  assert.equal(restartRequiredForFiles(['start.command']), true);
   assert.equal(restartRequiredForFiles(['public/index.html', 'test/foo.test.js']), false);
   assert.equal(restartRequiredForFiles(['release.json']), false);
 });

--- a/test/comfy-object-info-timeout.test.js
+++ b/test/comfy-object-info-timeout.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const server = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+test('ComfyUI object metadata gets a shared long timeout and a distinct error', () => {
+  assert.match(server, /const COMFY_OBJECT_INFO_TIMEOUT_MS = 60_000/);
+  assert.match(server, /AbortSignal\.timeout\(COMFY_OBJECT_INFO_TIMEOUT_MS\)/);
+  assert.match(server, /wrapped\.code = 'comfy_object_info_timeout'/);
+  assert.doesNotMatch(server, /getObjectInfo\([^\n]*AbortSignal\.timeout\((?:4000|6000)\)/);
+});

--- a/test/comfy-start.test.js
+++ b/test/comfy-start.test.js
@@ -74,6 +74,33 @@ test('Desktop-managed Comfy opens the official app instead of bypassing its Pyth
   }
 });
 
+test('macOS starts a source ComfyUI with Metal-safe launch settings', async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'mix-comfy-mac-start-'));
+  const base = path.join(temp, 'ComfyUI');
+  const python = path.join(base, '.venv', 'bin', 'python');
+  fs.mkdirSync(path.dirname(python), { recursive: true });
+  fs.mkdirSync(path.join(base, 'models'), { recursive: true });
+  fs.writeFileSync(path.join(base, 'main.py'), '');
+  fs.writeFileSync(python, '');
+  try {
+    const runtime = { comfy: { path: base, url: 'http://127.0.0.1:8188' } };
+    const options = { platform: 'darwin', env: {}, home: path.join(temp, 'missing'), fsImpl: fs };
+    const status = startStatus(runtime, options);
+    assert.equal(status.canStart, true);
+    assert.equal(status.kind, 'python');
+    assert.deepEqual(status.launchArgs, [
+      path.join(base, 'main.py'), '--listen', '127.0.0.1', '--port', '8188',
+      '--fp32-vae', '--use-split-cross-attention',
+    ]);
+    assert.deepEqual(status.launchEnv, { PYTORCH_ENABLE_MPS_FALLBACK: '1' });
+    let launched = null;
+    await startComfy(runtime, () => {}, Object.assign({}, options, { spawn(value) { launched = value; } }));
+    assert.equal(launched.pythonPath, python);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
 test('the Start API is owner-only, operation-safe, and separate from task-killing restart', () => {
   const server = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
   const startRoute = server.slice(server.indexOf("route === '/api/comfy/start'"), server.indexOf("route === '/api/comfy/restart'"));
@@ -175,6 +202,38 @@ test('restart kills only a verified ComfyUI listener before relaunching portable
     });
     assert.deepEqual(calls.find(([command]) => command === 'taskkill'), ['taskkill', ['/PID', '55', '/T', '/F']]);
     assert.equal(launched.kind, 'portable');
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test('macOS restart sends TERM only to the verified source ComfyUI listener', async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'mix-comfy-mac-restart-'));
+  const base = path.join(temp, 'ComfyUI');
+  const python = path.join(base, '.venv', 'bin', 'python');
+  const mainPy = path.join(base, 'main.py');
+  fs.mkdirSync(path.dirname(python), { recursive: true });
+  fs.mkdirSync(path.join(base, 'models'), { recursive: true });
+  fs.writeFileSync(mainPy, '');
+  fs.writeFileSync(python, '');
+  const calls = [];
+  let listenerChecks = 0;
+  let launched = null;
+  try {
+    await restartComfy({ comfy: { path: base, url: 'http://localhost:8188' } }, () => {}, {
+      platform: 'darwin', env: {}, home: path.join(temp, 'missing'), fsImpl: fs,
+      run: async (command, args) => {
+        calls.push([command, args]);
+        if (command === '/usr/sbin/lsof') return listenerChecks++ === 0 ? '77\n' : '';
+        if (command === '/bin/ps') return `77 ${python} ${mainPy} --port 8188`;
+        return '';
+      },
+      wait: async () => {},
+      spawn(status) { launched = status; },
+    });
+    assert.deepEqual(calls.find(([command]) => command === '/bin/kill'), ['/bin/kill', ['-TERM', '77']]);
+    assert.equal(calls.some(([command]) => command === 'taskkill'), false);
+    assert.deepEqual(launched.launchEnv, { PYTORCH_ENABLE_MPS_FALLBACK: '1' });
   } finally {
     fs.rmSync(temp, { recursive: true, force: true });
   }

--- a/test/comfy-widget-spec.test.js
+++ b/test/comfy-widget-spec.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isWidgetSpec, isWidgetType } = require('../lib/comfy-widget-spec');
+
+test('Comfy widget detection accepts numeric unions and widget hints', () => {
+  assert.equal(isWidgetType('FLOAT,INT'), true);
+  assert.equal(isWidgetSpec(['FLOAT,INT', { default: 1 }]), true);
+  assert.equal(isWidgetSpec(['LATENT,IMAGE']), false);
+  assert.equal(isWidgetSpec(['LATENT,IMAGE', { widgetType: 'FLOAT' }]), true);
+  assert.equal(isWidgetSpec(['COMFY_DYNAMICCOMBO', { options: [] }]), true);
+  assert.equal(isWidgetSpec([['one', 'two']]), true);
+});

--- a/test/dependency-manager.test.js
+++ b/test/dependency-manager.test.js
@@ -23,6 +23,7 @@ const {
   ensureUv,
   findExistingModelByBasename,
   filterProtectedRuntimeRequirements,
+  filterRequirementsForEnvironment,
   huggingFaceEndpointUrl,
   huggingFaceAccessUrl,
   installComponents,
@@ -32,6 +33,7 @@ const {
   modelIsRegistered,
   normalizeHuggingFaceEndpoint,
   patchLtxVideoKornia,
+  patchBfsOptionalAudio,
   protectedRuntimeConstraints,
   requirementsArgs,
   sameRepo,
@@ -83,6 +85,8 @@ test('dependency catalog covers every enabled image and video family', () => {
   assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxTextEncoder')[2], /Comfy-Org\/ltx-2\/resolve\/main\/split_files\/text_encoders\/gemma_3_12B_it_fp4_mixed\.safetensors/);
   assert.match(MODEL_ASSETS.ltx.find((asset) => asset[0] === 'ltxGemmaLora')[2], /Comfy-Org\/ltx-2/);
   assert.match(MODEL_ASSETS.ltxEdit[0][2], /Alissonerdx\/EditAnything/);
+  assert.match(MODEL_ASSETS.faceid.find((asset) => asset[0] === 'ltxFaceIdLora')[2], /Alissonerdx\/LTX-Best-Face-ID\/resolve\/main\/Best_FaceID_v1\.0_LoRA\.safetensors/);
+  assert.match(MODEL_ASSETS.faceid.find((asset) => asset[0] === 'ltxFaceIdDistilledLora')[2], /Comfy-Org\/ltx-2\.3\/resolve\/main\/split_files\/loras\/ltx_2\.3_22b_distilled_1\.1_lora_dynamic_fro09_avg_rank_111_bf16\.safetensors/);
   const qwenAngles = MODEL_ASSETS.qwen.find((asset) => asset[0] === 'qwenEditAnglesLora');
   assert.match(qwenAngles[2], /fal\/Qwen-Image-Edit-2511-Multiple-Angles-LoRA\/resolve\/main\/qwen-image-edit-2511-multiple-angles-lora\.safetensors/);
   assert.equal(qwenAngles[3], 'qwen_image_edit_2511_multiple-angles-lora.safetensors');
@@ -90,6 +94,8 @@ test('dependency catalog covers every enabled image and video family', () => {
   const scailSam = MODEL_ASSETS.scail.find((asset) => asset[0] === 'scailSam');
   assert.match(scailSam[2], /Comfy-Org\/sam3\.1\/resolve\/main\/checkpoints\/sam3\.1_multiplex_fp16\.safetensors/);
   assert.doesNotMatch(scailSam[2], /Comfy-Org\/SCAIL-2/);
+  assert.match(MODEL_ASSETS.scail.find((asset) => asset[0] === 'scailPusaLora')[2], /Kijai\/WanVideo_comfy\/resolve\/main\/Pusa\/Wan21_PusaV1_LoRA_14B_rank512_bf16\.safetensors/);
+  assert.match(MODEL_ASSETS.scail.find((asset) => asset[0] === 'scailClipVision')[2], /Comfy-Org\/Wan_2\.1_ComfyUI_repackaged\/resolve\/main\/split_files\/clip_vision\/clip_vision_h\.safetensors/);
   assert.ok(MODEL_ASSETS.wan.filter((asset) => /Unet$/.test(asset[0]))
     .every((asset) => /Comfy-Org\/Wan_2\.2_ComfyUI_Repackaged/.test(asset[2])));
   assert.match(MODEL_ASSETS.eros.find((asset) => asset[0] === 'erosTextEncoder')[2], /gemma_3_12B_it_heretic_fp8_e4m3fn/);
@@ -191,6 +197,16 @@ test('fresh Klein 4B setup installs FP8 while preserving an existing BF16 select
   const existingUnet = existing.assets.find((asset) => asset[0] === 'klein4Unet');
   assert.match(existingUnet[2], /FLUX\.2-klein-4B/);
   assert.match(existingUnet[2], /flux-2-klein-4b\.safetensors/);
+});
+
+test('Apple LTX setup selects the official BF16 checkpoint', () => {
+  const plan = dependencyModelPlan(['ltx'], {
+    ltxCkpt: 'ltx-2.3-22b-dev-fp8.safetensors',
+  }, { gpuVendor: 'apple' });
+  const checkpoint = plan.assets.find((asset) => asset[0] === 'ltxCkpt');
+  assert.equal(plan.settingUpdates.ltxCkpt, 'ltx-2.3-22b-dev.safetensors');
+  assert.match(checkpoint[2], /Lightricks\/LTX-2\.3\/resolve\/main\/ltx-2\.3-22b-dev\.safetensors/);
+  assert.doesNotMatch(checkpoint[2], /LTX-2\.3-fp8/);
 });
 
 test('automatic Director node installs use the reviewed commit while compatible checkouts are reused', async () => {
@@ -846,7 +862,8 @@ test('dependency routes run asynchronously and publish progress instead of holdi
   assert.match(server, /\.\.\.EMPTY_DEPENDENCY_FAILURE/);
   assert.match(server, /broadcast\('dependencyInstall'/);
   assert.match(server, /await assertDesktopIsIdle\(\)/);
-  assert.match(server, /getObjectInfo\(true, \{ signal: AbortSignal\.timeout\(4000\) \}\)/);
+  assert.match(server, /const COMFY_OBJECT_INFO_TIMEOUT_MS = 60_000/);
+  assert.match(server, /getObjectInfo\(true\)/);
   assert.match(server, /const discovery = await discoverModels\(/);
   assert.match(server, /availableModelRoots,/);
   assert.match(server, /const socketStale = socketOpen && Date\.now\(\) - lastWsMessageAt > 15_000/);
@@ -950,6 +967,16 @@ test('custom-node requirements fall back to uv for pip-less and broken portable 
   }
 });
 
+test('a loaded Windows OpenCV binary reports a specific retry path', async () => {
+  await assert.rejects(installNodeRequirements(
+    { pythonPath: 'comfy-python', basePath: 'ComfyUI' },
+    'requirements.txt',
+    false,
+    () => {},
+    { run: async () => { throw new Error("[WinError 5] Access is denied: 'cv2.pyd'"); } },
+  ), (error) => error.code === 'dependency_requirements_locked' && /stop ComfyUI completely/i.test(error.message));
+});
+
 test('one conflicting node pack does not block unrelated selected workflows', async () => {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-node-isolation-'));
   const customNodesPath = path.join(rootDir, 'custom_nodes');
@@ -1041,4 +1068,41 @@ test('repair requirements never reinstall ComfyUI runtime packages from PyPI', (
   assert.doesNotMatch(filtered, /torch|numpy|opencv/i);
   assert.match(filtered, /diffusers>=0.33.1/);
   assert.match(filtered, /omegaconf>=2.3.0/);
+});
+
+test('normal node installs preserve the OpenCV distribution already loaded by ComfyUI', () => {
+  const filtered = filterRequirementsForEnvironment([
+    'numpy>=2', 'opencv-python-headless>=4.9', 'color-matcher', 'torch',
+  ].join('\n'), [
+    'numpy==2.2.6', 'opencv-python==4.12.0.88', 'torch==2.11.0',
+  ].join('\n'));
+  assert.equal(filtered, 'color-matcher');
+});
+
+test('macOS BFS setup omits optional librosa without omitting Face ID requirements', () => {
+  const filtered = filterRequirementsForEnvironment([
+    'torch', 'numpy', 'librosa', 'opencv-python', 'insightface==0.7.3', 'onnxruntime',
+  ].join('\n'), '', { omitPackages: ['librosa'] });
+  assert.doesNotMatch(filtered, /librosa/);
+  assert.match(filtered, /insightface==0\.7\.3/);
+  assert.match(filtered, /onnxruntime/);
+});
+
+test('BFS optional audio import is guarded idempotently', async () => {
+  const nodePath = fs.mkdtempSync(path.join(os.tmpdir(), 'mixbox-bfs-patch-'));
+  const init = path.join(nodePath, '__init__.py');
+  try {
+    fs.writeFileSync(init, [
+      'from .amv_guide_node import NODE_CLASS_MAPPINGS as AMV_NODE_CLASS_MAPPINGS',
+      'from .amv_guide_node import NODE_DISPLAY_NAME_MAPPINGS as AMV_NODE_DISPLAY_NAME_MAPPINGS',
+      'NODE_CLASS_MAPPINGS = {**AMV_NODE_CLASS_MAPPINGS}',
+    ].join('\n'));
+    assert.equal(await patchBfsOptionalAudio(nodePath), true);
+    const patched = fs.readFileSync(init, 'utf8');
+    assert.match(patched, /try:\n    from \.amv_guide_node/);
+    assert.match(patched, /AMV Guide node not loaded/);
+    assert.equal(await patchBfsOptionalAudio(nodePath), false);
+  } finally {
+    fs.rmSync(nodePath, { recursive: true, force: true });
+  }
 });

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -31,7 +31,7 @@ test('installer manifest exposes optional edit and video components', () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'installer', 'feature-manifest.json'), 'utf8'));
   const ids = manifest.features.map((feature) => feature.id);
   const optionalIds = manifest.features.filter((feature) => feature.required !== true).map((feature) => feature.id).sort();
-  assert.equal(manifest.target, 'windows-nvidia');
+  assert.equal(manifest.target, 'desktop-generation');
   assert.deepEqual(optionalIds, Object.keys(DEFAULT_FEATURES).sort());
   assert.ok(ids.includes('core.image'));
   assert.ok(ids.includes('edit.qwen'));

--- a/test/folder-picker.test.js
+++ b/test/folder-picker.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  browseGenerationFolder,
+  browseMacFolder,
+  macFolderPickerScript,
+} = require('../lib/folder-picker');
+
+test('macOS folder picker returns a normalized POSIX folder', async () => {
+  const calls = [];
+  const selected = await browseMacFolder('models', {
+    execFileFn(command, args, options, callback) {
+      calls.push({ command, args, options });
+      callback(null, '/Users/test/ComfyUI/models/\n', '');
+    },
+  });
+  assert.equal(selected, '/Users/test/ComfyUI/models');
+  assert.equal(calls[0].command, '/usr/bin/osascript');
+  assert.deepEqual(calls[0].args.slice(0, 1), ['-e']);
+  assert.match(calls[0].args[1], /choose folder with prompt/);
+  assert.match(macFolderPickerScript('Choose "ComfyUI"'), /Choose \\"ComfyUI\\"/);
+});
+
+test('macOS folder picker treats user cancellation as an empty selection', async () => {
+  const selected = await browseGenerationFolder('comfy', {
+    platform: 'darwin',
+    execFileFn(_command, _args, _options, callback) {
+      callback(Object.assign(new Error('cancelled'), { code: 1 }), '', 'execution error: User canceled. (-128)');
+    },
+  });
+  assert.equal(selected, '');
+});
+
+test('folder picker reports unsupported platforms without invoking a desktop command', () => {
+  assert.throws(() => browseGenerationFolder('comfy', { platform: 'linux' }), (error) => (
+    error.code === 'folder_picker_unavailable' && /absolute path manually/i.test(error.message)
+  ));
+});

--- a/test/generation-capabilities.test.js
+++ b/test/generation-capabilities.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  configuredVideoEngineCapability,
+  dependencyComponentBlock,
+  ltxRefinePreflight,
+  videoEngineCapabilities,
+} = require('../lib/generation-capabilities');
+
+const apple = { gpuVendor: 'apple', gpuBackend: 'mps', vramGb: 64 };
+const nvidia = { gpuVendor: 'nvidia', gpuBackend: 'cuda', vramGb: 24 };
+
+test('Apple Metal exposes BF16 LTX and disables curated FP8 video families', () => {
+  const capabilities = videoEngineCapabilities(apple);
+  assert.equal(capabilities.ltx.supported, true);
+  assert.equal(capabilities.ltx.requiresBf16, true);
+  assert.equal(capabilities['ltx-edit'].supported, true);
+  for (const engine of ['eros', 'wan', 'scail']) {
+    assert.equal(capabilities[engine].supported, false);
+    assert.match(capabilities[engine].reason, /FP8|Apple Metal/);
+  }
+  assert.match(dependencyComponentBlock('scailinfinity', apple), /Apple Metal/);
+  assert.equal(dependencyComponentBlock('wan', nvidia), '');
+});
+
+test('Apple LTX generation rejects FP8 configuration and accepts BF16', () => {
+  assert.equal(configuredVideoEngineCapability('ltx', apple, {
+    ltxCkpt: 'ltx-2.3-22b-dev-fp8.safetensors',
+  }).supported, false);
+  assert.equal(configuredVideoEngineCapability('ltx', apple, {
+    ltxCkpt: 'ltx-2.3-22b-dev.safetensors',
+  }).supported, true);
+});
+
+test('LTX refine preflight catches the reported large Apple request before queueing', () => {
+  const unsafe = ltxRefinePreflight({ width: 1600, height: 896, frames: 273, fps: 25, profile: apple });
+  assert.equal(unsafe.ok, false);
+  assert.ok(unsafe.maxSeconds < 11);
+  assert.match(unsafe.error, /too large/);
+
+  assert.equal(ltxRefinePreflight({ width: 1280, height: 1280, frames: 201, fps: 25, profile: apple }).ok, true);
+  assert.equal(ltxRefinePreflight({ width: 1600, height: 896, frames: 273, fps: 25, profile: nvidia }).ok, true);
+});
+
+test('video UI consumes server capability gating', () => {
+  const root = path.join(__dirname, '..');
+  const app = fs.readFileSync(path.join(root, 'public', 'app.js'), 'utf8');
+  const server = fs.readFileSync(path.join(root, 'server.js'), 'utf8');
+  assert.match(app, /state\.videoCapabilities = lastMeta\.capabilities\?\.video \|\| \{\}/);
+  assert.match(app, /function supportedVideoEngines\(\)/);
+  assert.match(app, /button\.disabled = capability\.supported === false/);
+  assert.match(app, /if \(capability\.supported === false\) \{[\s\S]{0,180}toast\(capability\.reason/);
+  assert.match(server, /function adoptDeviceCompatibleModelSettings/);
+  assert.match(server, /settings\.ltxCkpt = 'ltx-2\.3-22b-dev\.safetensors'/);
+});

--- a/test/hardware-info.test.js
+++ b/test/hardware-info.test.js
@@ -6,6 +6,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const {
+  parseComfyStatsDevices,
   parseNvidiaGpuCsv,
   readDiskInfo,
   hardwareInfo,
@@ -19,9 +20,18 @@ const css = fs.readFileSync(path.join(root, 'public', 'style.css'), 'utf8');
 
 test('parses NVIDIA GPU identity, VRAM, and driver information', () => {
   assert.deepEqual(parseNvidiaGpuCsv('NVIDIA GeForce RTX 5090, 32607, 576.80\nNVIDIA RTX A6000, 49140, 576.80'), [
-    { name: 'NVIDIA GeForce RTX 5090', memoryBytes: 32607 * 1024 * 1024, driver: '576.80' },
-    { name: 'NVIDIA RTX A6000', memoryBytes: 49140 * 1024 * 1024, driver: '576.80' },
+    { name: 'NVIDIA GeForce RTX 5090', memoryBytes: 32607 * 1024 * 1024, driver: '576.80', vendor: 'nvidia', backend: 'cuda' },
+    { name: 'NVIDIA RTX A6000', memoryBytes: 49140 * 1024 * 1024, driver: '576.80', vendor: 'nvidia', backend: 'cuda' },
   ]);
+});
+
+test('reads Apple Metal identity from ComfyUI system stats', () => {
+  assert.deepEqual(parseComfyStatsDevices({ devices: [{
+    name: 'mps:0 Apple M4 Max', type: 'mps', vram_total: 64 * 1024 ** 3,
+  }] }), [{
+    name: 'Apple M4 Max', memoryBytes: 64 * 1024 ** 3, memoryKind: 'unified',
+    driver: '', vendor: 'apple', backend: 'mps', source: 'comfyui',
+  }]);
 });
 
 test('reads free and total capacity from the configured export storage drive', async () => {
@@ -77,12 +87,14 @@ test('reports the integrated Apple Silicon GPU with unified memory', async () =>
     memoryBytes: 48 * 1024 ** 3,
     memoryKind: 'unified',
     driver: '',
+    vendor: 'apple',
+    backend: 'mps',
   }]);
 });
 
 test('Advanced Settings presents hardware as one minimal System readout', () => {
   assert.match(server, /route === '\/api\/hardware'/);
-  assert.match(server, /hardwareInfo\(\{ exportPath: settings\.exportDir \|\| DATA \}\)/);
+  assert.match(server, /getSetupHardwareInfo\(true\)/);
   assert.match(html, /class="settings-group hardware-group"/);
   for (const id of ['hardwareGpu', 'hardwareCpu', 'hardwareMemory', 'hardwareOs', 'hardwareDisk']) {
     assert.match(html, new RegExp(`id="${id}"`));

--- a/test/portable-installer.test.js
+++ b/test/portable-installer.test.js
@@ -645,6 +645,23 @@ test('hardware guidance rates model families by VRAM without enforcing system RA
   assert.equal(combinedHardwareFit(QUICK_SETUP_COMPONENTS, difficult).level, 'difficult');
 });
 
+test('hardware guidance blocks incompatible Apple FP8 video families while retaining LTX', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, 'installer', 'feature-manifest.json'), 'utf8'));
+  const apple = {
+    gpu: { available: true, devices: [{
+      name: 'Apple M4 Max', vendor: 'apple', backend: 'mps', memoryBytes: 64 * (1024 ** 3),
+    }] },
+    memory: { totalBytes: 64 * (1024 ** 3) },
+    disk: { freeBytes: 500 * (1024 ** 3) },
+  };
+  const guidance = componentHardwareGuidance(manifest, apple);
+  assert.equal(guidance.video.blocked, undefined);
+  for (const component of ['eros', 'wan', 'scail', 'scailinfinity']) {
+    assert.equal(guidance[component].blocked, true);
+    assert.match(guidance[component].detail, /Apple Metal/);
+  }
+});
+
 test('portable setup validates connection input and preserves machine settings', () => {
   assert.equal(normalizeSetupUrl('http://127.0.0.1:8188/'), 'http://127.0.0.1:8188');
   assert.throws(() => normalizeSetupUrl('ftp://example.test'), /http:\/\/ or https:\/\//);

--- a/test/portable-installer.test.js
+++ b/test/portable-installer.test.js
@@ -36,6 +36,21 @@ test('portable installer starts the web app before generation setup', () => {
   assert.doesNotMatch(start, /MixBox Studio/);
 });
 
+test('macOS installer clones the official checkout and launches through the restart-aware command', () => {
+  const installer = fs.readFileSync(path.join(root, 'install_MixStudio.command'), 'utf8');
+  const start = fs.readFileSync(path.join(root, 'start.command'), 'utf8');
+  assert.match(installer, /https:\/\/github\.com\/BlackMixture\/Mix-Studio\.git/);
+  assert.match(installer, /clone --depth 1 --branch main --single-branch/);
+  assert.match(installer, /Node\.js 22 or newer/);
+  assert.match(installer, /installer\/bootstrap\.js/);
+  assert.match(installer, /exec \/bin\/zsh "\$MIX_STUDIO_HOME\/start\.command"/);
+  assert.match(start, /MIXBOX_RESTART_MODE=launcher/);
+  assert.match(start, /PYTORCH_ENABLE_MPS_FALLBACK/);
+  assert.match(start, /process\.versions\.node\.split/);
+  assert.match(start, /http:\/\/127\.0\.0\.1:\$\{PORT:-3300\}\//);
+  assert.match(start, /STATUS.*-eq 75/s);
+});
+
 test('standalone installer downloads the official Git checkout before opening the app', () => {
   const launcher = fs.readFileSync(path.join(root, 'install_MixStudio.bat'), 'utf8');
   assert.match(launcher, /https:\/\/github\.com\/BlackMixture\/Mix-Studio\.git/);
@@ -100,7 +115,10 @@ test('GitHub Pages publishes the canonical installer from a branded download pag
   assert.match(page, /Download for Windows/);
   assert.match(page, /href="\.\/install_MixStudio\.bat" download="install_MixStudio\.bat"/);
   assert.equal((page.match(/platform-icon platform-windows/g) || []).length, 4);
-  assert.match(page, /macOS support coming soon/);
+  assert.match(page, /Download for macOS/);
+  assert.match(page, /href="\.\/install_MixStudio\.command" download="install_MixStudio\.command"/);
+  assert.equal((page.match(/platform-icon platform-macos/g) || []).length, 4);
+  assert.doesNotMatch(page, /macOS (?:support|download) coming soon/);
   assert.doesNotMatch(page, /Setup continues inside Mix Studio/);
   assert.doesNotMatch(page, /The installer gets you into Mix Studio before asking you to choose models or workflows\./);
   assert.match(page, /class="download quick-download"/);
@@ -271,6 +289,7 @@ test('GitHub Pages publishes the canonical installer from a branded download pag
   assert.match(page, /Your studio/);
   assert.doesNotMatch(page, /—/);
   assert.match(workflow, /cp install_MixStudio\.bat _site\/install_MixStudio\.bat/);
+  assert.match(workflow, /cp install_MixStudio\.command _site\/install_MixStudio\.command/);
   assert.match(workflow, /cp docs\/download\/mix-studio-wordmark\.svg _site\/mix-studio-wordmark\.svg/);
   assert.match(workflow, /cp docs\/download\/mix-studio-create\.webp _site\/mix-studio-create\.webp/);
   assert.match(workflow, /cp docs\/download\/comfyui-logo\.svg _site\/comfyui-logo\.svg/);
@@ -396,6 +415,27 @@ test('bootstrap recognizes current Comfy Desktop instances and ignores incomplet
       status: 'installing',
     }]));
     assert.equal(desktopComfyPath({ APPDATA: appData }, fs, path), '');
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test('bootstrap recognizes a source ComfyUI virtual environment on macOS', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'mix-comfy-mac-bootstrap-'));
+  const home = path.join(temp, 'home');
+  const comfyRoot = path.join(home, 'ComfyUI');
+  const python = path.join(comfyRoot, '.venv', 'bin', 'python');
+  fs.mkdirSync(path.dirname(python), { recursive: true });
+  fs.writeFileSync(path.join(comfyRoot, 'main.py'), '');
+  fs.writeFileSync(python, '');
+  try {
+    assert.equal(desktopComfyPath({ HOME: home }, fs, path), comfyRoot);
+    const config = portableBootstrapConfig(path.join(temp, 'checkout'), {
+      env: { HOME: home },
+      now: '2026-08-02T00:00:00.000Z',
+    });
+    assert.equal(config.comfy.path, comfyRoot);
+    assert.equal(config.comfy.modelsPath, path.join(comfyRoot, 'models'));
   } finally {
     fs.rmSync(temp, { recursive: true, force: true });
   }

--- a/test/repository-delivery.test.js
+++ b/test/repository-delivery.test.js
@@ -32,10 +32,10 @@ test('the current release has user-facing Krea 2 Edit and Remix notes', () => {
   assert.match(changelog, /Krea 2 Remix/);
 });
 
-test('quality runs the complete Node 22 checks on Linux and Windows', () => {
+test('quality runs the complete Node 22 checks on Linux, Windows, and macOS', () => {
   assert.match(quality, /workflow_call:/);
   assert.match(quality, /pull_request:/);
-  assert.match(quality, /os: \[ubuntu-latest, windows-latest\]/);
+  assert.match(quality, /os: \[ubuntu-latest, windows-latest, macos-latest\]/);
   assert.match(quality, /node-version: 22/);
   assert.match(quality, /node --check server\.js/);
   assert.match(quality, /node --check public\/app\.js/);
@@ -44,6 +44,9 @@ test('quality runs the complete Node 22 checks on Linux and Windows', () => {
   assert.match(quality, /Smoke test installer batch helpers/);
   assert.match(quality, /install_MixStudio\.bat --verify-checkout/);
   assert.match(quality, /install_MixStudio\.bat --verify-node/);
+  assert.match(quality, /Check macOS launchers/);
+  assert.match(quality, /zsh -n install_MixStudio\.command/);
+  assert.match(quality, /zsh -n start\.command/);
   assert.match(quality, /node --test/);
   assert.match(quality, /RELEASE_TAG/);
   assert.match(quality, /release\.json/);

--- a/test/windows-folder-picker.test.js
+++ b/test/windows-folder-picker.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { browseWindowsFolder, folderPickerScript } = require('../lib/windows-folder-picker');
+
+test('Windows picker falls back to the Shell folder browser', () => {
+  const script = folderPickerScript('Choose ComfyUI');
+  assert.match(script, /System\.Windows\.Forms\.FolderBrowserDialog/);
+  assert.match(script, /Shell\.Application/);
+  assert.match(script, /BrowseForFolder/);
+});
+
+test('Windows picker uses STA PowerShell and reports an actionable failure', async () => {
+  const calls = [];
+  const systemRoot = 'C:\\Windows';
+  await assert.rejects(browseWindowsFolder('models', {
+    env: { SystemRoot: systemRoot },
+    execFileFn: (command, args, options, callback) => {
+      calls.push({ command, args, options });
+      callback(Object.assign(new Error('Command failed'), { code: 1 }), '', 'both pickers failed');
+    },
+  }), (error) => error.code === 'folder_picker_failed' && /enter the folder path manually/i.test(error.message));
+  assert.equal(calls[0].command, path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'));
+  assert.deepEqual(calls[0].args.slice(0, 3), ['-NoProfile', '-STA', '-Command']);
+});


### PR DESCRIPTION
## Summary
- fix the completed dependency, model-source, and ComfyUI compatibility issues
- add the supported Apple Silicon install, launch, setup, capability, and restart path
- publish macOS download links and support boundaries in the repository README and GitHub Pages site
- validate the repository on Linux, Windows, and macOS

## Validation
- `node --check server.js`
- `node --check public/app.js`
- `node --test` (911 passed, 1 skipped)

## macOS support boundary
Krea image workflows and official BF16 LTX 2.3 are supported through source-based ComfyUI on Apple Metal. Curated FP8-only 10Eros, Wan 2.2, and SCAIL 2 remain disabled with explicit guidance.