### PR TITLE
Refine download button hierarchy

### DIFF
--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -64,6 +64,11 @@
     .download:hover, .download:focus-visible { transform: translateY(-2px); box-shadow: 0 18px 58px rgba(46,67,255,.3); }
     .download svg { width: 19px; height: 19px; }
     .download .platform-windows { width: 20px; height: 20px; }
+    .download-actions { align-items: flex-start; flex-direction: column; gap: 8px; }
+    .download-alternatives { display: flex; align-items: center; gap: 2px; margin-left: 8px; }
+    .download-secondary { min-height: 34px; display: inline-flex; align-items: center; justify-content: center; padding: 0 10px; border-radius: 10px; color: var(--muted); font-size: 12px; font-weight: 800; text-decoration: none; transition: color 180ms ease, background 180ms ease; }
+    .download-secondary:hover { background: rgba(157,179,247,.08); color: var(--ink); }
+    .download-secondary:focus-visible { outline: 2px solid #76a8ff; outline-offset: 2px; background: rgba(157,179,247,.08); color: var(--ink); }
     .platform-coming { min-height: 42px; display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 0 14px; border: 1px solid var(--line); border-radius: 14px; background: rgba(10,12,18,.72); color: var(--muted); font-size: 11px; font-weight: 750; white-space: nowrap; }
     .platform-coming svg { width: 16px; height: 16px; color: var(--soft); }
     .hero-visual { position: relative; padding: 1px; border-radius: 22px; background: linear-gradient(125deg,rgba(66,133,244,.72),rgba(234,67,53,.2) 38%,rgba(118,87,255,.68)); box-shadow: 0 34px 100px rgba(10,21,74,.36); }
@@ -285,6 +290,7 @@
     @keyframes speed-metric-in { to { opacity: 1; transform: translateY(0); } }
     .download-band { display: grid; justify-items: center; gap: 29px; padding: 28px; border: 1px solid var(--line); border-radius: 20px; background: radial-gradient(60% 120% at 50% 100%,rgba(66,133,244,.08),transparent 68%),#07090d; }
     .download-band-actions { display: flex; flex-wrap: wrap; align-items: stretch; justify-content: center; gap: 12px; }
+    .download-band-actions.download-actions { align-items: center; gap: 8px; }
     .download-band .download, .download-band .platform-coming { min-width: 248px; }
     .download-band .platform-coming { min-height: 56px; padding-inline: 22px; border-radius: 18px; font-size: 12px; background: rgba(10,12,18,.82); }
     .download-band-tagline { margin: 0; color: #9db3f7; font-size: 10px; font-weight: 850; letter-spacing: .16em; line-height: 1; text-transform: uppercase; }
@@ -420,6 +426,7 @@
     .closing h2 { font-size: clamp(36px,4.5vw,54px); }
     .closing-copy p { margin: 18px 0 0; color: var(--muted); line-height: 1.6; }
     .closing-actions { position: relative; z-index: 1; flex: 0 0 auto; display: flex; flex-direction: column; align-items: stretch; gap: 10px; }
+    .closing-actions.download-actions { align-items: center; gap: 8px; }
     .closing .download { position: relative; z-index: 1; flex: 0 0 auto; }
     .closing .platform-coming { background: rgba(6,8,13,.6); }
     .site-footer { padding: 30px 0 42px; border-top: 1px solid var(--line); color: var(--muted); font-size: 12px; }
@@ -468,6 +475,8 @@
       h1 { font-size: clamp(48px,15.5vw,68px); }
       .actions { align-items: stretch; flex-direction: column; }
       .download, .platform-coming { width: 100%; }
+      .download-alternatives { width: 100%; margin-left: 0; justify-content: center; }
+      .download-secondary { flex: 1 1 0; min-height: 40px; }
       .proof { grid-template-columns: 1fr; }
       .proof-item { padding-inline: 0; }
       .proof-item + .proof-item { border-left: 0; border-top: 1px solid var(--line); }
@@ -579,13 +588,15 @@
         <div class="hero-copy">
           <h1>Your studio.<br />On your machine.</h1>
           <p class="lede">A clean, responsive AI workspace built on ComfyUI. Run highly tuned image and video workflows flawlessly from your desktop or your phone. Features curated setups for Krea 2, Flux Klein, Qwen Edit, LTX 2.3, Wan 2.2, and SCAIL 2.</p>
-          <div class="actions">
+          <div class="actions download-actions">
             <a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat">
               <svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>
               Download for Windows
             </a>
-            <a class="download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>Download for macOS</a>
-            <a class="download download-linux" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm"><svg class="platform-icon platform-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v14H4V5Zm3 4 3 3-3 3m5 0h5"/></svg>Linux setup</a>
+            <div class="download-alternatives" aria-label="Other platforms">
+              <a class="download-secondary" href="./install_MixStudio.command" download="install_MixStudio.command">Download for macOS</a>
+              <a class="download-secondary" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm">Linux setup</a>
+            </div>
           </div>
         </div>
         <div class="hero-visual" aria-label="Mix Studio Create Image interface">
@@ -624,7 +635,7 @@
         <div class="quick-copy">
           <p class="section-kicker">Quick start</p>
           <h2>Open the app. Finish setup in one place.</h2>
-          <div class="actions"><a class="download quick-download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Windows</a><a class="download quick-download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>macOS</a><a class="download quick-download download-linux" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm"><svg class="platform-icon platform-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v14H4V5Zm3 4 3 3-3 3m5 0h5"/></svg>Linux</a></div>
+          <div class="actions download-actions"><a class="download quick-download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a><div class="download-alternatives" aria-label="Other platforms"><a class="download-secondary" href="./install_MixStudio.command" download="install_MixStudio.command">Download for macOS</a><a class="download-secondary" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm">Linux setup</a></div></div>
         </div>
         <div class="step-list">
           <article class="guide-step"><div><h3>Launch Mix Studio</h3><p>Run the installer on Windows or macOS. On Linux, clone the repository and run <code>./start-mixstudio.sh</code>. Mix Studio opens setup automatically.</p></div></article>
@@ -687,10 +698,9 @@
       </section>
 
       <section class="download-band" aria-label="Download Mix Studio">
-        <div class="download-band-actions">
+        <div class="download-band-actions download-actions">
           <a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a>
-          <a class="download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>Download for macOS</a>
-          <a class="download download-linux" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm"><svg class="platform-icon platform-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v14H4V5Zm3 4 3 3-3 3m5 0h5"/></svg>Linux setup</a>
+          <div class="download-alternatives" aria-label="Other platforms"><a class="download-secondary" href="./install_MixStudio.command" download="install_MixStudio.command">Download for macOS</a><a class="download-secondary" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm">Linux setup</a></div>
         </div>
         <p class="download-band-tagline">Free &amp; Open Source</p>
       </section>
@@ -742,7 +752,7 @@
 
       <section class="closing">
         <div class="closing-copy"><p class="section-kicker">Desktop power, mobile freedom</p><h2>Your GPU stays home.<br />Your studio comes with you.</h2></div>
-        <div class="closing-actions"><a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a><a class="download download-macos" href="./install_MixStudio.command" download="install_MixStudio.command"><svg class="platform-icon platform-macos" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M16.7 13.1c0-2.9 2.4-4.3 2.5-4.4-1.4-2-3.5-2.2-4.2-2.2-1.8-.2-3.5 1-4.4 1s-2.3-1-3.8-1c-2 0-3.8 1.2-4.8 3-2.1 3.6-.5 9 1.5 11.9 1 1.4 2.1 3 3.7 2.9 1.5-.1 2.1-1 3.9-1s2.3 1 3.9 1c1.7 0 2.8-1.4 3.8-2.9 1.2-1.7 1.7-3.4 1.7-3.5-.1 0-3.8-1.5-3.8-5.9ZM13.8 4.6c.9-1.1 1.5-2.6 1.4-4.1-1.3.1-2.9.9-3.8 2-.8.9-1.6 2.4-1.4 3.8 1.5.1 2.9-.7 3.8-1.7Z"/></svg>Download for macOS</a><a class="download download-linux" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm"><svg class="platform-icon platform-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v14H4V5Zm3 4 3 3-3 3m5 0h5"/></svg>Linux setup</a></div>
+        <div class="closing-actions download-actions"><a class="download" href="./install_MixStudio.bat" download="install_MixStudio.bat"><svg class="platform-icon platform-windows" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2.5 4.3 10.6 3v8H2.5V4.3Zm9.2-1.5 9.8-1.4V11h-9.8V2.8ZM2.5 12.2h8.1v8l-8.1-1.1v-6.9Zm9.2 0h9.8v9.7l-9.8-1.4v-8.3Z"/></svg>Download for Windows</a><div class="download-alternatives" aria-label="Other platforms"><a class="download-secondary" href="./install_MixStudio.command" download="install_MixStudio.command">Download for macOS</a><a class="download-secondary" href="https://github.com/BlackMixture/Mix-Studio/blob/main/docs/installation-and-operations.md#linux-setup-nvidia-or-amd-rocm">Linux setup</a></div></div>
       </section>
     </main>
 

--- a/test/portable-installer.test.js
+++ b/test/portable-installer.test.js
@@ -128,10 +128,12 @@ test('GitHub Pages publishes the canonical installer from a branded download pag
   assert.equal((page.match(/platform-icon platform-windows/g) || []).length, 4);
   assert.match(page, /Download for macOS/);
   assert.match(page, /href="\.\/install_MixStudio\.command" download="install_MixStudio\.command"/);
-  assert.equal((page.match(/platform-icon platform-macos/g) || []).length, 4);
+  assert.equal((page.match(/class="download-secondary" href="\.\/install_MixStudio\.command"/g) || []).length, 4);
+  assert.equal((page.match(/platform-icon platform-macos/g) || []).length, 0);
   assert.match(page, /Linux setup/);
   assert.match(page, /installation-and-operations\.md#linux-setup-nvidia-or-amd-rocm/);
-  assert.equal((page.match(/platform-icon platform-linux/g) || []).length, 4);
+  assert.equal((page.match(/class="download-secondary" href="https:\/\/github\.com\/BlackMixture\/Mix-Studio\/blob\/main\/docs\/installation-and-operations\.md#linux-setup-nvidia-or-amd-rocm"/g) || []).length, 4);
+  assert.equal((page.match(/platform-icon platform-linux/g) || []).length, 0);
   assert.match(page, /AMD ROCm on Windows or Linux is experimental/);
   assert.doesNotMatch(page, /macOS (?:support|download) coming soon/);
   assert.doesNotMatch(page, /Setup continues inside Mix Studio/);


### PR DESCRIPTION
## What changed

- keep Windows as the single primary download button
- present macOS download and Linux setup as smaller, icon-free text links
- apply the hierarchy consistently across the hero, quick start, download band, and closing CTA
- preserve clear hover and keyboard-focus feedback with touch-safe mobile targets
- update the delivery contract to enforce the new icon-free secondary links

## Why

The three platform actions previously had identical visual weight. This makes the main Windows path immediately clear while keeping macOS and Linux easy to find.

## Validation

- `node --test --test-reporter=dot`
- `git diff --check`
- rendered at 1440 × 1000 and 390 × 844 with no horizontal overflow
- verified hover and keyboard-focus states in Chrome
